### PR TITLE
Add is_simulation to DagRun and rebase simulation migration onto 3.3.0

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0112_3_3_0_add_simulation_fields.py
+++ b/airflow-core/src/airflow/migrations/versions/0112_3_3_0_add_simulation_fields.py
@@ -17,11 +17,11 @@
 # under the License.
 
 """
-Add simulation fields to TaskInstance.
+Add simulation fields to task_instance and dag_run.
 
-Revision ID: a1b2c3d4e5f6
-Revises: 6222ce48e289
-Create Date: 2026-03-09 00:00:00.000000
+Revision ID: 49ed3350068d
+Revises: 9fabad868fdb
+Create Date: 2026-04-24 00:00:00.000000
 
 """
 
@@ -30,29 +30,37 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "a1b2c3d4e5f6"
-down_revision = "6222ce48e289"
+revision = "49ed3350068d"
+down_revision = "9fabad868fdb"
 branch_labels = None
 depends_on = None
-airflow_version = "3.2.0"
+airflow_version = "3.3.0"
 
 
 def upgrade():
-    """Add is_simulation, estimated_runtime, and predicted_outcome to task_instance."""
+    """Add is_simulation, estimated_runtime, predicted_outcome to task_instance; is_simulation to dag_run."""
     with op.batch_alter_table("task_instance", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("is_simulation", sa.Boolean, nullable=False, server_default="0"),
+            sa.Column("is_simulation", sa.Boolean(), nullable=False, server_default=sa.false()),
         )
         batch_op.add_column(
-            sa.Column("estimated_runtime", sa.Float, nullable=True),
+            sa.Column("estimated_runtime", sa.Float(), nullable=True),
         )
         batch_op.add_column(
-            sa.Column("predicted_outcome", sa.String(20), nullable=True),
+            sa.Column("predicted_outcome", sa.String(length=50), nullable=True),
+        )
+
+    with op.batch_alter_table("dag_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("is_simulation", sa.Boolean(), nullable=False, server_default=sa.false()),
         )
 
 
 def downgrade():
-    """Remove simulation fields from task_instance."""
+    """Remove simulation fields from task_instance and dag_run."""
+    with op.batch_alter_table("dag_run", schema=None) as batch_op:
+        batch_op.drop_column("is_simulation")
+
     with op.batch_alter_table("task_instance", schema=None) as batch_op:
         batch_op.drop_column("predicted_outcome")
         batch_op.drop_column("estimated_runtime")

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -33,6 +33,7 @@ from opentelemetry.trace import StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from sqlalchemy import (
     JSON,
+    Boolean,
     Enum,
     ForeignKey,
     ForeignKeyConstraint,
@@ -232,6 +233,9 @@ class DagRun(Base, LoggingMixin):
 
     partition_key: Mapped[str | None] = mapped_column(StringID(), nullable=True)
     partition_date: Mapped[datetime | None] = mapped_column(UtcDateTime, nullable=True)
+
+    # Simulation flag (Sprint 2)
+    is_simulation: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=false())
 
     # Remove this `if` after upgrading Sphinx-AutoAPI
     if not TYPE_CHECKING and "BUILDING_AIRFLOW_DOCS" in os.environ:

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -588,11 +588,9 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
     dag_version = relationship("DagVersion", back_populates="task_instances")
 
     # Simulation fields (Sprint 2)
-    is_simulation: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default="0"
-    )
+    is_simulation: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=false())
     estimated_runtime: Mapped[float | None] = mapped_column(Float, nullable=True)
-    predicted_outcome: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    predicted_outcome: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
     __table_args__ = (
         Index("ti_dag_state", dag_id, state),


### PR DESCRIPTION
---                                                                                                                
  Adds the DB layer for DAG Simulation: alembic migration + DagRun.is_simulation ORM column, rebased onto Airflow      
  3.3.0. This unblocks wiring run_simulation() / SimulationExecutor through to persistence in follow-up PRs.           
                                                                                                                       
  Migration 0112_3_3_0_add_simulation_fields.py (down_revision = 9fabad868fdb):                                        
                                                                                                                       
  - task_instance.is_simulation (BOOLEAN, NOT NULL, default 0)                                                         
  - task_instance.estimated_runtime (FLOAT, nullable)                                                                  
  - task_instance.predicted_outcome (VARCHAR(50), nullable)                                                          
  - dag_run.is_simulation (BOOLEAN, NOT NULL, default 0)                                                               
                                         
  Model changes:                                                                                                       
                                                                                                                       
  - DagRun — new is_simulation mapped column matching the migration.                                                   
  - TaskInstance — Sprint 2 sim fields tightened to server_default=false(); predicted_outcome widened String(20) →     
  String(50).                                                                                                          
                                                                                                                       
  Verified:                                                                                                            
                                                                                                                       
  - 18/18 unit tests pass (airflow-core/tests/unit/models/test_taskinstance_simulation.py).                            
  - airflow db migrate on a fresh SQLite stamps head 49ed3350068d; schema dump confirms all four columns with correct  
  types/defaults.                        
  - SQL round-trip proves the new columns persist values written through the ORM.                                      
                                                                                                                     
  Known follow-ups:                                                                                                    
                                                                                                                     
  - Merge conflict expected with historical_predict on predictor_interface.py — pick theirs (has Apache header +       
  trailing commas).              
  - No scheduler/API/UI wiring yet; nothing invokes run_simulation() in response to a user action.                     
                                                                                                                     
  related: #9                                                                                                          
                                                                                                                     
  ---                                                                                                                  
  Was generative AI tooling used to co-author this PR?                                                                 
                                                      
  - Yes — Claude Code (Opus 4.7)                                                                                       
                                                                                                                       
  Generated-by: Claude Code (Opus 4.7) following                                                                       
  https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions     
                                                                                                                       
  ---                                                                                                                
  - Read the https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines
   for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
  - For fundamental code changes, an Airflow Improvement Proposal                                                      
  (https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals) is needed.                       
  - When adding dependency, check compliance with the https://www.apache.org/legal/resolved.html#category-x.           
  - For significant user-facing changes create newsfragment: {pr_number}.significant.rst, in                           
  https://github.com/apache/airflow/tree/main/airflow-core/newsfragments.                                            
                                         
  ---                                                                                                                  
  Note: the closes: #9 wasn't quite right — issue #9 is what historical_db closes. If there's a tracking issue for the
  DB migration work on your team board, swap in closes: #<that> or drop the line. Want me to check the repo's issues?  
