### PR TITLE
Add Unit Tests for DAG Simulation Feature

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
@@ -64,12 +64,8 @@ def _get_dag_for_dag_run(dag_run: DagRun, dag_id: str, session: SessionDep):
 
 @simulation_router.post(
     "/simulate",
-    responses=create_openapi_http_exception_doc(
-        [status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT]
-    ),
-    dependencies=[
-        Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.TASK_INSTANCE))
-    ],
+    responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT]),
+    dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.TASK_INSTANCE))],
 )
 def run_simulation(
     dag_id: str,
@@ -77,10 +73,7 @@ def run_simulation(
 ) -> SimulationResponse:
     """Run a simulation for all tasks in the most recent DAG run."""
     dag_run = session.scalar(
-        select(DagRun)
-        .where(DagRun.dag_id == dag_id)
-        .order_by(DagRun.start_date.desc())
-        .limit(1)
+        select(DagRun).where(DagRun.dag_id == dag_id).order_by(DagRun.start_date.desc()).limit(1)
     )
     if dag_run is None:
         raise HTTPException(
@@ -88,9 +81,7 @@ def run_simulation(
             f"No DAG runs found for dag_id: `{dag_id}`",
         )
 
-    task_instances = session.scalars(
-        select(TI).where(TI.dag_id == dag_id, TI.run_id == dag_run.run_id)
-    ).all()
+    task_instances = session.scalars(select(TI).where(TI.dag_id == dag_id, TI.run_id == dag_run.run_id)).all()
 
     if not task_instances:
         raise HTTPException(
@@ -98,13 +89,9 @@ def run_simulation(
             f"No task instances found for dag_id: `{dag_id}`, run_id: `{dag_run.run_id}`",
         )
 
-    
     historical_predictor = HistoricalPredictor()
-    tasks = [
-        {"task_id": ti.task_id, "operator_type": ti.operator or "Unknown"}
-        for ti in task_instances
-    ]
-    
+    tasks = [{"task_id": ti.task_id, "operator_type": ti.operator or "Unknown"} for ti in task_instances]
+
     estimates = []
     total_runtime = 0
     for t in tasks:
@@ -132,14 +119,14 @@ def run_simulation(
         dag = _get_dag_for_dag_run(dag_run, dag_id, session)
 
     critical_path_response = get_critical_path(dag, task_responses)
-        
+
     response = SimulationResponse(
         simulation_id=simulation_id,
         dag_id=dag_id,
         task_estimates=task_responses,
         total_estimated_seconds=total_runtime,
-        critical_path=critical_path_response, #bottle neck is returned in this function
-        predicted_outcome="success", #TODO: replace with actual model prediction in the future implementation
+        critical_path=critical_path_response,  # bottle neck is returned in this function
+        predicted_outcome="success",  # TODO: replace with actual model prediction in the future implementation
     )
 
     simulation_run_id = DagRunType.SIMULATION.generate_run_id(suffix=simulation_id)
@@ -165,9 +152,7 @@ def run_simulation(
 @simulation_router.get(
     "/simulate/{simulation_id}",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
-    dependencies=[
-        Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.TASK_INSTANCE))
-    ],
+    dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.TASK_INSTANCE))],
 )
 def get_simulation(
     dag_id: str,

--- a/airflow-core/src/airflow/migrations/versions/0112_3_3_0_add_simulation_fields.py
+++ b/airflow-core/src/airflow/migrations/versions/0112_3_3_0_add_simulation_fields.py
@@ -20,7 +20,7 @@
 Add simulation fields to task_instance and dag_run.
 
 Revision ID: 49ed3350068d
-Revises: 9fabad868fdb
+Revises: fde9ed84d07b
 Create Date: 2026-04-24 00:00:00.000000
 
 """
@@ -31,7 +31,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "49ed3350068d"
-down_revision = "9fabad868fdb"
+down_revision = "fde9ed84d07b"
 branch_labels = None
 depends_on = None
 airflow_version = "3.3.0"

--- a/airflow-core/src/airflow/simulation/critical_path.py
+++ b/airflow-core/src/airflow/simulation/critical_path.py
@@ -21,6 +21,7 @@ This module calculates a simple longest-path over the DAG task dependency
 graph using estimated runtimes. It produces a critical path, the edges along
 that path, and the task with the longest duration on the path.
 """
+
 from __future__ import annotations
 
 from collections import deque

--- a/airflow-core/src/airflow/simulation/data/historical_data_extractor.py
+++ b/airflow-core/src/airflow/simulation/data/historical_data_extractor.py
@@ -166,18 +166,15 @@ def get_historical_runtimes_by_operator(
     limit = min(max(limit, 1), DEFAULT_LIMIT)
     offset = max(offset, 0)
 
-    stmt = (
-        select(
-            TaskInstance.run_id,
-            TaskInstance.duration,
-            TaskInstance.start_date,
-            TaskInstance.end_date,
-            TaskInstance.state,
-        )
-        .where(
-            TaskInstance.operator == operator_type,
-            TaskInstance.state.in_(states),
-        )
+    stmt = select(
+        TaskInstance.run_id,
+        TaskInstance.duration,
+        TaskInstance.start_date,
+        TaskInstance.end_date,
+        TaskInstance.state,
+    ).where(
+        TaskInstance.operator == operator_type,
+        TaskInstance.state.in_(states),
     )
 
     if start_date is not None:
@@ -189,11 +186,7 @@ def get_historical_runtimes_by_operator(
     if exclude_simulations and hasattr(TaskInstance, "is_simulation"):
         stmt = stmt.where(TaskInstance.is_simulation.is_(False))
 
-    stmt = (
-        stmt.order_by(TaskInstance.start_date.desc())
-        .limit(limit)
-        .offset(offset)
-    )
+    stmt = stmt.order_by(TaskInstance.start_date.desc()).limit(limit).offset(offset)
 
     rows = session.execute(stmt).all()
 

--- a/airflow-core/src/airflow/simulation/simulation_executor.py
+++ b/airflow-core/src/airflow/simulation/simulation_executor.py
@@ -42,7 +42,7 @@ class SimulationExecutor(BaseExecutor):
         team_name: str | None = None,
     ) -> None:
         self.predictor = predictor or DeterministicPredictor()
-        
+
         super().__init__(parallelism=parallelism, team_name=team_name)
 
     def _process_workloads(self, workload_list: Sequence[workloads.All]):

--- a/airflow-core/src/airflow/ui/src/utils/simulationDisplay.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/simulationDisplay.test.ts
@@ -1,0 +1,213 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  getSimulationDisplayOptions,
+  getSimulationTaskDisplayMetadata,
+  type SimulationReportLike,
+} from "./simulationDisplay";
+
+const makeReport = (
+  overrides: Partial<SimulationReportLike> = {},
+): SimulationReportLike => ({
+  task_estimates: [
+    { task_id: "a", estimated_seconds: 5 },
+    { task_id: "b", estimated_seconds: 30 },
+    { task_id: "c", estimated_seconds: 10 },
+  ],
+  critical_path: {
+    critical_path: ["a", "b"],
+    longest_task: "b",
+  },
+  ...overrides,
+});
+
+describe("getSimulationDisplayOptions", () => {
+  it("returns both flags false when no params are set", () => {
+    const params = new URLSearchParams();
+
+    expect(getSimulationDisplayOptions(params)).toEqual({
+      showCriticalPath: false,
+      showDurationBottleneck: false,
+    });
+  });
+
+  it("treats sim_cp=1 as enabling critical-path overlay", () => {
+    const params = new URLSearchParams("sim_cp=1");
+
+    expect(getSimulationDisplayOptions(params).showCriticalPath).toBe(true);
+  });
+
+  it("treats sim_duration=1 as enabling duration-bottleneck overlay", () => {
+    const params = new URLSearchParams("sim_duration=1");
+
+    expect(getSimulationDisplayOptions(params).showDurationBottleneck).toBe(true);
+  });
+
+  it("does not enable a flag for non-'1' truthy-looking values", () => {
+    const params = new URLSearchParams("sim_cp=true&sim_duration=yes");
+
+    expect(getSimulationDisplayOptions(params)).toEqual({
+      showCriticalPath: false,
+      showDurationBottleneck: false,
+    });
+  });
+});
+
+describe("getSimulationTaskDisplayMetadata", () => {
+  const taskIds = ["a", "b", "c"];
+
+  it("returns no critical-path or bottleneck signals when both flags are off", () => {
+    const result = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: false, showDurationBottleneck: false },
+      undefined,
+      makeReport(),
+    );
+
+    for (const taskId of taskIds) {
+      expect(result[taskId]).toEqual({
+        isBottleneck: false,
+        isCriticalPath: false,
+        metricLabel: undefined,
+      });
+    }
+  });
+
+  it("flags critical-path tasks when showCriticalPath is on", () => {
+    const result = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: true, showDurationBottleneck: false },
+      undefined,
+      makeReport(),
+    );
+
+    expect(result.a?.isCriticalPath).toBe(true);
+    expect(result.b?.isCriticalPath).toBe(true);
+    expect(result.c?.isCriticalPath).toBe(false);
+  });
+
+  it("filters reported critical-path tasks that are not present in the rendered DAG", () => {
+    // Report says ["x", "a"] is the critical path, but "x" isn't in taskIds.
+    const result = getSimulationTaskDisplayMetadata(
+      ["a", "b"],
+      { showCriticalPath: true, showDurationBottleneck: false },
+      undefined,
+      makeReport({
+        critical_path: { critical_path: ["x", "a"], longest_task: "x" },
+      }),
+    );
+
+    expect(result.a?.isCriticalPath).toBe(true);
+    expect(result.b?.isCriticalPath).toBe(false);
+  });
+
+  it("marks the highest-duration task as the bottleneck when showDurationBottleneck is on", () => {
+    const result = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: false, showDurationBottleneck: true },
+      undefined,
+      makeReport(),
+    );
+
+    // b is 30s, the largest in the report.
+    expect(result.b?.isBottleneck).toBe(true);
+    expect(result.a?.isBottleneck).toBe(false);
+    expect(result.c?.isBottleneck).toBe(false);
+  });
+
+  it("attaches a duration metric label only when bottleneck overlay is on", () => {
+    const withFlag = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: false, showDurationBottleneck: true },
+      undefined,
+      makeReport(),
+    );
+    const withoutFlag = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: false, showDurationBottleneck: false },
+      undefined,
+      makeReport(),
+    );
+
+    expect(withFlag.a?.metricLabel).toBe("Dur: 5s");
+    expect(withFlag.b?.metricLabel).toBe("Dur: 30s");
+    expect(withoutFlag.a?.metricLabel).toBeUndefined();
+  });
+
+  it("returns no bottleneck and no labels when the report is undefined", () => {
+    const result = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: true, showDurationBottleneck: true },
+      undefined,
+      undefined,
+    );
+
+    for (const taskId of taskIds) {
+      expect(result[taskId]).toEqual({
+        isBottleneck: false,
+        isCriticalPath: false,
+        metricLabel: undefined,
+      });
+    }
+  });
+
+  it("ignores tasks present in the report but missing from the rendered DAG", () => {
+    // "ghost" is in the report but not in the taskIds list — must not appear in metadata.
+    const result = getSimulationTaskDisplayMetadata(
+      ["a", "b"],
+      { showCriticalPath: false, showDurationBottleneck: true },
+      undefined,
+      {
+        task_estimates: [
+          { task_id: "a", estimated_seconds: 1 },
+          { task_id: "b", estimated_seconds: 2 },
+          { task_id: "ghost", estimated_seconds: 999 },
+        ],
+        critical_path: { critical_path: [], longest_task: "" },
+      },
+    );
+
+    expect(Object.keys(result).sort()).toEqual(["a", "b"]);
+    // Bottleneck must be on-render: b (2s) wins over a (1s); ghost is excluded.
+    expect(result.b?.isBottleneck).toBe(true);
+    expect(result.a?.isBottleneck).toBe(false);
+  });
+
+  it("breaks ties by keeping the first task encountered", () => {
+    // a and b tie at 5s. The reduce uses strict ``>``, so the first task to claim
+    // the max keeps it — "a" wins because it appears first in the taskIds array.
+    const result = getSimulationTaskDisplayMetadata(
+      ["a", "b"],
+      { showCriticalPath: false, showDurationBottleneck: true },
+      undefined,
+      {
+        task_estimates: [
+          { task_id: "a", estimated_seconds: 5 },
+          { task_id: "b", estimated_seconds: 5 },
+        ],
+        critical_path: { critical_path: [], longest_task: "" },
+      },
+    );
+
+    expect(result.a?.isBottleneck).toBe(true);
+    expect(result.b?.isBottleneck).toBe(false);
+  });
+});

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
@@ -138,10 +138,12 @@ class TestRunSimulation(TestSimulationEndpoint):
         dag_runs_response = test_client.get(f"/dags/{DAG_ID}/dagRuns?run_type=simulation")
         assert dag_runs_response.status_code == 200
         dag_runs = dag_runs_response.json()["dag_runs"]
-        # The created run must carry both the simulation run_type and a run_id
+        # The DagRunResponse pydantic model serializes ``run_id`` as ``dag_run_id``.
+        # The created run must carry both the simulation run_type and a run id
         # suffixed with this specific simulation_id.
         assert any(
-            run["run_type"] == "simulation" and run["run_id"].endswith(simulation_id) for run in dag_runs
+            run["run_type"] == "simulation" and run["dag_run_id"].endswith(simulation_id)
+            for run in dag_runs
         )
 
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
@@ -18,12 +18,11 @@ from __future__ import annotations
 
 import pytest
 
+from airflow._shared.timezones.timezone import datetime
 from airflow.models import DagRun, TaskInstance
 from airflow.models.dag_version import DagVersion
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
-
-from airflow._shared.timezones.timezone import datetime
 
 from tests_common.test_utils.db import clear_db_runs
 
@@ -139,8 +138,11 @@ class TestRunSimulation(TestSimulationEndpoint):
         dag_runs_response = test_client.get(f"/dags/{DAG_ID}/dagRuns?run_type=simulation")
         assert dag_runs_response.status_code == 200
         dag_runs = dag_runs_response.json()["dag_runs"]
-        assert any(run["run_id"].startswith("simulation__") for run in dag_runs)
-        assert any(run["run_type"] == "simulation" for run in dag_runs)
+        # The created run must carry both the simulation run_type and a run_id
+        # suffixed with this specific simulation_id.
+        assert any(
+            run["run_type"] == "simulation" and run["run_id"].endswith(simulation_id) for run in dag_runs
+        )
 
 
 class TestGetSimulation(TestSimulationEndpoint):
@@ -174,3 +176,83 @@ class TestGetSimulation(TestSimulationEndpoint):
         get_data = get_response.json()
 
         assert post_data == get_data
+
+
+class TestResultCachePersistence(TestSimulationEndpoint):
+    """Pin the in-memory result-cache contract.
+
+    Simulation results are stored in a module-level dict in
+    ``airflow.api_fastapi.core_api.routes.public.simulation``. These tests
+    ensure that:
+
+    1. Multiple simulations on the same DAG do not overwrite each other —
+       a consequence of UUID4-keyed entries.
+    2. A simulation_id is scoped to its originating DAG and cannot be
+       fetched through another DAG's URL path.
+    """
+
+    def test_two_consecutive_simulations_are_both_retrievable(self, test_client, session):
+        self.create_dag_run_with_tasks(session)
+
+        first = test_client.post(f"/dags/{DAG_ID}/simulate")
+        second = test_client.post(f"/dags/{DAG_ID}/simulate")
+        assert first.status_code == 200
+        assert second.status_code == 200
+
+        first_id = first.json()["simulation_id"]
+        second_id = second.json()["simulation_id"]
+        assert first_id != second_id
+
+        first_fetch = test_client.get(f"/dags/{DAG_ID}/simulate/{first_id}")
+        second_fetch = test_client.get(f"/dags/{DAG_ID}/simulate/{second_id}")
+        assert first_fetch.status_code == 200
+        assert second_fetch.status_code == 200
+        assert first_fetch.json()["simulation_id"] == first_id
+        assert second_fetch.json()["simulation_id"] == second_id
+
+    def test_simulation_id_is_scoped_to_originating_dag(self, test_client, session):
+        # POST on DAG A, then try to fetch the simulation through DAG B's path.
+        # Even if the cache has the entry, the route must reject the cross-DAG read.
+        self.create_dag_run_with_tasks(session)
+
+        post_response = test_client.post(f"/dags/{DAG_ID}/simulate")
+        simulation_id = post_response.json()["simulation_id"]
+
+        cross_dag_response = test_client.get(f"/dags/some_other_dag/simulate/{simulation_id}")
+
+        assert cross_dag_response.status_code == 404
+
+
+class TestSimulationAccessControl(TestSimulationEndpoint):
+    """Pin the auth posture of /simulate.
+
+    The current route is gated by ``requires_access_dag(method="GET", ...)``
+    even though POST creates a real DagRun. These tests pin the *current*
+    behavior so that any tightening of permissions (e.g. requiring write
+    access on POST) is a deliberate change covered by an updated test, not
+    a silent regression.
+    """
+
+    def test_post_returns_401_for_unauthenticated_client(self, unauthenticated_test_client, session):
+        self.create_dag_run_with_tasks(session)
+
+        response = unauthenticated_test_client.post(f"/dags/{DAG_ID}/simulate")
+
+        assert response.status_code == 401
+
+    def test_post_returns_403_for_unauthorized_client(self, unauthorized_test_client, session):
+        self.create_dag_run_with_tasks(session)
+
+        response = unauthorized_test_client.post(f"/dags/{DAG_ID}/simulate")
+
+        assert response.status_code == 403
+
+    def test_get_returns_401_for_unauthenticated_client(self, unauthenticated_test_client):
+        response = unauthenticated_test_client.get(f"/dags/{DAG_ID}/simulate/any-id")
+
+        assert response.status_code == 401
+
+    def test_get_returns_403_for_unauthorized_client(self, unauthorized_test_client):
+        response = unauthorized_test_client.get(f"/dags/{DAG_ID}/simulate/any-id")
+
+        assert response.status_code == 403

--- a/airflow-core/tests/unit/migrations/test_simulation_migration.py
+++ b/airflow-core/tests/unit/migrations/test_simulation_migration.py
@@ -46,7 +46,10 @@ class TestMigrationMetadata:
     def test_down_revision_chains_off_previous_head(self, migration):
         # Hard-pin so a future migration insertion doesn't silently re-parent
         # this one (which would corrupt the migration graph for existing DBs).
-        assert migration.down_revision == "9fabad868fdb"
+        # Re-parented from "9fabad868fdb" to "fde9ed84d07b" after main brought
+        # in 0112_3_3_0_add_task_state_and_asset_state_tables, which would
+        # otherwise share our parent and cause "multiple heads" errors.
+        assert migration.down_revision == "fde9ed84d07b"
 
     def test_no_branch_labels(self, migration):
         assert migration.branch_labels is None

--- a/airflow-core/tests/unit/migrations/test_simulation_migration.py
+++ b/airflow-core/tests/unit/migrations/test_simulation_migration.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Structural tests for the ``add_simulation_fields`` migration.
+
+A real upgrade/downgrade roundtrip is exercised by Airflow's existing
+migration test infrastructure (which runs the full chain against sqlite
+and postgres). These tests pin the small things that don't need a live
+DB: the revision identifiers, the airflow_version stamp, and that both
+``upgrade``/``downgrade`` modules are importable and callable.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+MIGRATION_MODULE = (
+    "airflow.migrations.versions.0112_3_3_0_add_simulation_fields"
+)
+
+
+@pytest.fixture
+def migration():
+    return importlib.import_module(MIGRATION_MODULE)
+
+
+class TestMigrationMetadata:
+    def test_revision_id(self, migration):
+        assert migration.revision == "49ed3350068d"
+
+    def test_down_revision_chains_off_previous_head(self, migration):
+        # Hard-pin so a future migration insertion doesn't silently re-parent
+        # this one (which would corrupt the migration graph for existing DBs).
+        assert migration.down_revision == "9fabad868fdb"
+
+    def test_no_branch_labels(self, migration):
+        assert migration.branch_labels is None
+        assert migration.depends_on is None
+
+    def test_airflow_version_stamp(self, migration):
+        assert migration.airflow_version == "3.3.0"
+
+
+class TestMigrationCallables:
+    def test_upgrade_is_callable(self, migration):
+        assert callable(migration.upgrade)
+
+    def test_downgrade_is_callable(self, migration):
+        assert callable(migration.downgrade)

--- a/airflow-core/tests/unit/simulation/data/test_historical_data_extractor.py
+++ b/airflow-core/tests/unit/simulation/data/test_historical_data_extractor.py
@@ -58,9 +58,12 @@ class TestGetHistoricalRuntimes:
         """Successful runs are returned with correct fields."""
         start = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            run_id="run1", state=TaskInstanceState.SUCCESS.value,
-            start=start, duration=10.0,
+            dag_maker,
+            session,
+            run_id="run1",
+            state=TaskInstanceState.SUCCESS.value,
+            start=start,
+            duration=10.0,
         )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, session=session)
@@ -82,14 +85,20 @@ class TestGetHistoricalRuntimes:
         """By default, only successful runs are returned."""
         start = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            run_id="success_run", state=TaskInstanceState.SUCCESS.value,
-            start=start, duration=5.0,
+            dag_maker,
+            session,
+            run_id="success_run",
+            state=TaskInstanceState.SUCCESS.value,
+            start=start,
+            duration=5.0,
         )
         _create_ti(
-            dag_maker, session,
-            run_id="failed_run", state=TaskInstanceState.FAILED.value,
-            start=start + timedelta(hours=1), duration=3.0,
+            dag_maker,
+            session,
+            run_id="failed_run",
+            state=TaskInstanceState.FAILED.value,
+            start=start + timedelta(hours=1),
+            duration=3.0,
         )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, session=session)
@@ -101,18 +110,25 @@ class TestGetHistoricalRuntimes:
         """Explicit state filter returns matching runs."""
         start = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            run_id="success_run", state=TaskInstanceState.SUCCESS.value,
-            start=start, duration=5.0,
+            dag_maker,
+            session,
+            run_id="success_run",
+            state=TaskInstanceState.SUCCESS.value,
+            start=start,
+            duration=5.0,
         )
         _create_ti(
-            dag_maker, session,
-            run_id="failed_run", state=TaskInstanceState.FAILED.value,
-            start=start + timedelta(hours=1), duration=3.0,
+            dag_maker,
+            session,
+            run_id="failed_run",
+            state=TaskInstanceState.FAILED.value,
+            start=start + timedelta(hours=1),
+            duration=3.0,
         )
 
         results = get_historical_runtimes(
-            DAG_ID, TASK_ID,
+            DAG_ID,
+            TASK_ID,
             states=[TaskInstanceState.FAILED.value],
             session=session,
         )
@@ -124,18 +140,25 @@ class TestGetHistoricalRuntimes:
         """Multiple states in filter returns all matching runs."""
         start = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            run_id="success_run", state=TaskInstanceState.SUCCESS.value,
-            start=start, duration=5.0,
+            dag_maker,
+            session,
+            run_id="success_run",
+            state=TaskInstanceState.SUCCESS.value,
+            start=start,
+            duration=5.0,
         )
         _create_ti(
-            dag_maker, session,
-            run_id="failed_run", state=TaskInstanceState.FAILED.value,
-            start=start + timedelta(hours=1), duration=3.0,
+            dag_maker,
+            session,
+            run_id="failed_run",
+            state=TaskInstanceState.FAILED.value,
+            start=start + timedelta(hours=1),
+            duration=3.0,
         )
 
         results = get_historical_runtimes(
-            DAG_ID, TASK_ID,
+            DAG_ID,
+            TASK_ID,
             states=[TaskInstanceState.SUCCESS.value, TaskInstanceState.FAILED.value],
             session=session,
         )
@@ -146,14 +169,20 @@ class TestGetHistoricalRuntimes:
         """Task with only failed runs returns empty with default state filter."""
         start = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            run_id="failed1", state=TaskInstanceState.FAILED.value,
-            start=start, duration=2.0,
+            dag_maker,
+            session,
+            run_id="failed1",
+            state=TaskInstanceState.FAILED.value,
+            start=start,
+            duration=2.0,
         )
         _create_ti(
-            dag_maker, session,
-            run_id="failed2", state=TaskInstanceState.FAILED.value,
-            start=start + timedelta(hours=1), duration=1.0,
+            dag_maker,
+            session,
+            run_id="failed2",
+            state=TaskInstanceState.FAILED.value,
+            start=start + timedelta(hours=1),
+            duration=1.0,
         )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, session=session)
@@ -164,13 +193,17 @@ class TestGetHistoricalRuntimes:
         base = datetime(2025, 1, 1, tzinfo=timezone.utc)
         for i in range(5):
             _create_ti(
-                dag_maker, session,
-                run_id=f"run_{i}", state=TaskInstanceState.SUCCESS.value,
-                start=base + timedelta(days=i), duration=10.0,
+                dag_maker,
+                session,
+                run_id=f"run_{i}",
+                state=TaskInstanceState.SUCCESS.value,
+                start=base + timedelta(days=i),
+                duration=10.0,
             )
 
         results = get_historical_runtimes(
-            DAG_ID, TASK_ID,
+            DAG_ID,
+            TASK_ID,
             start_date=base + timedelta(days=1),
             end_date=base + timedelta(days=3),
             session=session,
@@ -184,13 +217,17 @@ class TestGetHistoricalRuntimes:
         base = datetime(2025, 1, 1, tzinfo=timezone.utc)
         for i in range(3):
             _create_ti(
-                dag_maker, session,
-                run_id=f"run_{i}", state=TaskInstanceState.SUCCESS.value,
-                start=base + timedelta(days=i), duration=10.0,
+                dag_maker,
+                session,
+                run_id=f"run_{i}",
+                state=TaskInstanceState.SUCCESS.value,
+                start=base + timedelta(days=i),
+                duration=10.0,
             )
 
         results = get_historical_runtimes(
-            DAG_ID, TASK_ID,
+            DAG_ID,
+            TASK_ID,
             start_date=base + timedelta(days=1),
             session=session,
         )
@@ -203,9 +240,12 @@ class TestGetHistoricalRuntimes:
         base = datetime(2025, 1, 1, tzinfo=timezone.utc)
         for i in range(3):
             _create_ti(
-                dag_maker, session,
-                run_id=f"run_{i}", state=TaskInstanceState.SUCCESS.value,
-                start=base + timedelta(days=i), duration=10.0,
+                dag_maker,
+                session,
+                run_id=f"run_{i}",
+                state=TaskInstanceState.SUCCESS.value,
+                start=base + timedelta(days=i),
+                duration=10.0,
             )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, session=session)
@@ -217,9 +257,12 @@ class TestGetHistoricalRuntimes:
         base = datetime(2025, 1, 1, tzinfo=timezone.utc)
         for i in range(5):
             _create_ti(
-                dag_maker, session,
-                run_id=f"run_{i}", state=TaskInstanceState.SUCCESS.value,
-                start=base + timedelta(days=i), duration=10.0,
+                dag_maker,
+                session,
+                run_id=f"run_{i}",
+                state=TaskInstanceState.SUCCESS.value,
+                start=base + timedelta(days=i),
+                duration=10.0,
             )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, limit=2, session=session)
@@ -234,9 +277,12 @@ class TestGetHistoricalRuntimes:
         base = datetime(2025, 1, 1, tzinfo=timezone.utc)
         for i in range(5):
             _create_ti(
-                dag_maker, session,
-                run_id=f"run_{i}", state=TaskInstanceState.SUCCESS.value,
-                start=base + timedelta(days=i), duration=10.0,
+                dag_maker,
+                session,
+                run_id=f"run_{i}",
+                state=TaskInstanceState.SUCCESS.value,
+                start=base + timedelta(days=i),
+                duration=10.0,
             )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, limit=2, offset=2, session=session)
@@ -249,9 +295,12 @@ class TestGetHistoricalRuntimes:
         """Limit values above DEFAULT_LIMIT are capped."""
         base = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            run_id="run_0", state=TaskInstanceState.SUCCESS.value,
-            start=base, duration=10.0,
+            dag_maker,
+            session,
+            run_id="run_0",
+            state=TaskInstanceState.SUCCESS.value,
+            start=base,
+            duration=10.0,
         )
 
         # Should not raise, just cap at DEFAULT_LIMIT
@@ -263,9 +312,12 @@ class TestGetHistoricalRuntimes:
         base = datetime(2025, 1, 1, tzinfo=timezone.utc)
         for i in range(3):
             _create_ti(
-                dag_maker, session,
-                run_id=f"run_{i}", state=TaskInstanceState.SUCCESS.value,
-                start=base + timedelta(days=i), duration=10.0,
+                dag_maker,
+                session,
+                run_id=f"run_{i}",
+                state=TaskInstanceState.SUCCESS.value,
+                start=base + timedelta(days=i),
+                duration=10.0,
             )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, limit=-5, session=session)
@@ -276,9 +328,12 @@ class TestGetHistoricalRuntimes:
         base = datetime(2025, 1, 1, tzinfo=timezone.utc)
         for i in range(3):
             _create_ti(
-                dag_maker, session,
-                run_id=f"run_{i}", state=TaskInstanceState.SUCCESS.value,
-                start=base + timedelta(days=i), duration=10.0,
+                dag_maker,
+                session,
+                run_id=f"run_{i}",
+                state=TaskInstanceState.SUCCESS.value,
+                start=base + timedelta(days=i),
+                duration=10.0,
             )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, offset=-10, session=session)
@@ -288,16 +343,22 @@ class TestGetHistoricalRuntimes:
         """Only returns task instances for the specified dag_id."""
         start = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            dag_id="dag_a", run_id="run_a",
+            dag_maker,
+            session,
+            dag_id="dag_a",
+            run_id="run_a",
             state=TaskInstanceState.SUCCESS.value,
-            start=start, duration=10.0,
+            start=start,
+            duration=10.0,
         )
         _create_ti(
-            dag_maker, session,
-            dag_id="dag_b", run_id="run_b",
+            dag_maker,
+            session,
+            dag_id="dag_b",
+            run_id="run_b",
             state=TaskInstanceState.SUCCESS.value,
-            start=start + timedelta(hours=1), duration=20.0,
+            start=start + timedelta(hours=1),
+            duration=20.0,
         )
 
         results = get_historical_runtimes("dag_a", TASK_ID, session=session)
@@ -336,9 +397,12 @@ class TestGetHistoricalRuntimes:
         """Handles task instances with null duration gracefully."""
         start = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            run_id="run_null", state=TaskInstanceState.SUCCESS.value,
-            start=start, duration=None,
+            dag_maker,
+            session,
+            run_id="run_null",
+            state=TaskInstanceState.SUCCESS.value,
+            start=start,
+            duration=None,
         )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, session=session)
@@ -351,9 +415,12 @@ class TestGetHistoricalRuntimes:
         """Results are HistoricalRuntime dataclass instances."""
         start = datetime(2025, 1, 1, tzinfo=timezone.utc)
         _create_ti(
-            dag_maker, session,
-            run_id="run1", state=TaskInstanceState.SUCCESS.value,
-            start=start, duration=10.0,
+            dag_maker,
+            session,
+            run_id="run1",
+            state=TaskInstanceState.SUCCESS.value,
+            start=start,
+            duration=10.0,
         )
 
         results = get_historical_runtimes(DAG_ID, TASK_ID, session=session)

--- a/airflow-core/tests/unit/simulation/predictors/test_historical_predictor.py
+++ b/airflow-core/tests/unit/simulation/predictors/test_historical_predictor.py
@@ -44,12 +44,8 @@ DAG_ID = "test_dag"
 TASK_ID = "test_task"
 CONTEXT = {"dag_id": DAG_ID}
 
-_PATCH_EXACT = (
-    "airflow.simulation.predictors.historical_predictor.get_historical_runtimes"
-)
-_PATCH_OPERATOR = (
-    "airflow.simulation.predictors.historical_predictor.get_historical_runtimes_by_operator"
-)
+_PATCH_EXACT = "airflow.simulation.predictors.historical_predictor.get_historical_runtimes"
+_PATCH_OPERATOR = "airflow.simulation.predictors.historical_predictor.get_historical_runtimes_by_operator"
 
 
 def _make_runtime(run_id: str, duration: float | None) -> HistoricalRuntime:
@@ -268,8 +264,7 @@ class TestHistoricalPredictorOperatorFallback:
         operator_runtimes = [_make_runtime(f"op_run_{i}", 25.0 + i) for i in range(5)]
         predictor = HistoricalPredictor(filter_outliers=False)
 
-        with patch(_PATCH_EXACT, return_value=[]), \
-             patch(_PATCH_OPERATOR, return_value=operator_runtimes):
+        with patch(_PATCH_EXACT, return_value=[]), patch(_PATCH_OPERATOR, return_value=operator_runtimes):
             result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         assert result.estimated_seconds == 27  # median of [25,26,27,28,29]
@@ -284,8 +279,7 @@ class TestHistoricalPredictorOperatorFallback:
         with patch(_PATCH_EXACT, return_value=exact_runtimes):
             exact_result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
-        with patch(_PATCH_EXACT, return_value=[]), \
-             patch(_PATCH_OPERATOR, return_value=operator_runtimes):
+        with patch(_PATCH_EXACT, return_value=[]), patch(_PATCH_OPERATOR, return_value=operator_runtimes):
             operator_result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         assert exact_result.confidence > operator_result.confidence
@@ -295,8 +289,7 @@ class TestHistoricalPredictorOperatorFallback:
         operator_runtimes = [_make_runtime("op_run_0", 25.0)]
         predictor = HistoricalPredictor(min_runs=3, filter_outliers=False)
 
-        with patch(_PATCH_EXACT, return_value=[]), \
-             patch(_PATCH_OPERATOR, return_value=operator_runtimes):
+        with patch(_PATCH_EXACT, return_value=[]), patch(_PATCH_OPERATOR, return_value=operator_runtimes):
             result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         assert result.estimated_seconds == _OPERATOR_RUNTIME_SECONDS[OperatorType.PYTHON]
@@ -304,17 +297,13 @@ class TestHistoricalPredictorOperatorFallback:
 
     def test_operator_fallback_with_outlier_filtering(self):
         """Outlier filtering applies to operator-type data too."""
-        operator_runtimes = [
-            _make_runtime(f"op_run_{i}", d)
-            for i, d in enumerate([20, 21, 22, 23, 20000])
-        ]
+        operator_runtimes = [_make_runtime(f"op_run_{i}", d) for i, d in enumerate([20, 21, 22, 23, 20000])]
         predictor = HistoricalPredictor(
             aggregation=AggregationMethod.MEAN,
             filter_outliers=True,
         )
 
-        with patch(_PATCH_EXACT, return_value=[]), \
-             patch(_PATCH_OPERATOR, return_value=operator_runtimes):
+        with patch(_PATCH_EXACT, return_value=[]), patch(_PATCH_OPERATOR, return_value=operator_runtimes):
             result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         assert result.estimated_seconds < 30
@@ -325,8 +314,10 @@ class TestHistoricalPredictorOperatorFallback:
         operator_runtimes = [_make_runtime(f"op_run_{i}", 99.0) for i in range(5)]
         predictor = HistoricalPredictor(filter_outliers=False)
 
-        with patch(_PATCH_EXACT, return_value=exact_runtimes), \
-             patch(_PATCH_OPERATOR, return_value=operator_runtimes) as mock_op:
+        with (
+            patch(_PATCH_EXACT, return_value=exact_runtimes),
+            patch(_PATCH_OPERATOR, return_value=operator_runtimes) as mock_op,
+        ):
             result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         assert result.estimated_seconds == 10
@@ -345,8 +336,7 @@ class TestHistoricalPredictorFullFallback:
         """No exact match, no operator data → DeterministicPredictor."""
         predictor = HistoricalPredictor()
 
-        with patch(_PATCH_EXACT, return_value=[]), \
-             patch(_PATCH_OPERATOR, return_value=[]):
+        with patch(_PATCH_EXACT, return_value=[]), patch(_PATCH_OPERATOR, return_value=[]):
             result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         assert result.estimated_seconds == _OPERATOR_RUNTIME_SECONDS[OperatorType.PYTHON]
@@ -357,8 +347,10 @@ class TestHistoricalPredictorFullFallback:
         none_runtimes = [_make_runtime(f"run_{i}", None) for i in range(5)]
         predictor = HistoricalPredictor()
 
-        with patch(_PATCH_EXACT, return_value=none_runtimes), \
-             patch(_PATCH_OPERATOR, return_value=none_runtimes):
+        with (
+            patch(_PATCH_EXACT, return_value=none_runtimes),
+            patch(_PATCH_OPERATOR, return_value=none_runtimes),
+        ):
             result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         assert result.confidence == _DETERMINISTIC_CONFIDENCE
@@ -369,8 +361,10 @@ class TestHistoricalPredictorFullFallback:
         operator_runtimes = [_make_runtime(f"op_run_{i}", 50.0) for i in range(5)]
         predictor = HistoricalPredictor(min_runs=3, filter_outliers=False)
 
-        with patch(_PATCH_EXACT, return_value=exact_runtimes), \
-             patch(_PATCH_OPERATOR, return_value=operator_runtimes):
+        with (
+            patch(_PATCH_EXACT, return_value=exact_runtimes),
+            patch(_PATCH_OPERATOR, return_value=operator_runtimes),
+        ):
             result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         assert result.estimated_seconds == 50
@@ -382,8 +376,10 @@ class TestHistoricalPredictorFullFallback:
         operator_runtimes = [_make_runtime(f"op_run_{i}", 50.0) for i in range(5)]
         predictor = HistoricalPredictor(min_runs=10, filter_outliers=False)
 
-        with patch(_PATCH_EXACT, return_value=exact_runtimes), \
-             patch(_PATCH_OPERATOR, return_value=operator_runtimes):
+        with (
+            patch(_PATCH_EXACT, return_value=exact_runtimes),
+            patch(_PATCH_OPERATOR, return_value=operator_runtimes),
+        ):
             result = predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
 
         # Both have 5 runs < min_runs=10, falls to heuristic

--- a/airflow-core/tests/unit/simulation/test_bottleneck.py
+++ b/airflow-core/tests/unit/simulation/test_bottleneck.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for bottleneck (longest_task) extraction inside ``get_critical_path``.
+
+The "bottleneck" is the single longest task on the critical path. It is
+populated as ``CriticalPathResult.longest_task`` by ``get_critical_path``;
+these tests exercise the extraction rule independently of overall path
+correctness (which is covered in ``test_critical_path``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from airflow.api_fastapi.core_api.datamodels.simulation import TaskSimulationResponse
+from airflow.simulation.critical_path import get_critical_path
+
+
+def _task(task_id: str, seconds: int) -> TaskSimulationResponse:
+    return TaskSimulationResponse(
+        task_id=task_id,
+        operator_type="PythonOperator",
+        estimated_seconds=seconds,
+        confidence=1.0,
+    )
+
+
+def _dag(edges: dict[str, list[str]]) -> SimpleNamespace:
+    referenced = set(edges) | {downstream for downstreams in edges.values() for downstream in downstreams}
+    task_dict = {
+        task_id: SimpleNamespace(
+            task_id=task_id,
+            downstream_task_ids=set(edges.get(task_id, [])),
+        )
+        for task_id in referenced
+    }
+    return SimpleNamespace(task_dict=task_dict)
+
+
+@pytest.mark.parametrize(
+    ("label", "edges", "runtimes", "expected_bottleneck"),
+    [
+        # Single task — it's trivially its own bottleneck.
+        (
+            "single_task",
+            {"a": []},
+            {"a": 7},
+            "a",
+        ),
+        # Linear chain — bottleneck is the longest task on the path.
+        (
+            "linear_chain_picks_max_on_path",
+            {"a": ["b"], "b": ["c"], "c": []},
+            {"a": 1, "b": 100, "c": 10},
+            "b",
+        ),
+        # Off-path task with the largest single runtime must NOT become the
+        # bottleneck. Here "x" is 10s but lives on a shorter parallel branch
+        # (a→x = 11) than the main chain (a→b→c→d = 12). Bottleneck is taken
+        # from the critical path itself, never from the full response set.
+        (
+            "off_path_task_is_not_a_bottleneck",
+            {"a": ["b", "x"], "b": ["c"], "c": ["d"], "d": [], "x": []},
+            {"a": 1, "b": 5, "c": 5, "d": 1, "x": 10},
+            # critical path is [a, b, c, d]; bottleneck ties b/c, lex max → "c".
+            "c",
+        ),
+        # Tie between two tasks on the path — ``max(..., key=(estimate, task_id))``
+        # breaks ties by lexically larger task_id.
+        (
+            "tied_runtimes_break_by_task_id",
+            {"a": ["b"], "b": ["c"], "c": []},
+            {"a": 5, "b": 5, "c": 5},
+            "c",
+        ),
+    ],
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_bottleneck_extraction(label, edges, runtimes, expected_bottleneck):
+    dag = _dag(edges)
+    tasks = [_task(tid, seconds) for tid, seconds in runtimes.items()]
+
+    result = get_critical_path(dag, tasks)
+
+    assert result.longest_task == expected_bottleneck, (
+        f"[{label}] expected {expected_bottleneck!r} on path {result.critical_path}, "
+        f"got {result.longest_task!r}"
+    )
+    # Sanity invariant: the bottleneck is always on the critical path itself.
+    assert result.longest_task in result.critical_path
+
+
+def test_empty_input_yields_empty_bottleneck():
+    """Empty task list should produce an empty bottleneck, not raise."""
+    result = get_critical_path(_dag({}), [])
+
+    assert result.longest_task == ""
+    assert result.critical_path == []

--- a/airflow-core/tests/unit/simulation/test_critical_path.py
+++ b/airflow-core/tests/unit/simulation/test_critical_path.py
@@ -1,0 +1,220 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for ``airflow.simulation.critical_path.get_critical_path``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from airflow.api_fastapi.core_api.datamodels.simulation import TaskSimulationResponse
+from airflow.simulation.critical_path import get_critical_path
+
+
+def _task(task_id: str, seconds: int) -> TaskSimulationResponse:
+    return TaskSimulationResponse(
+        task_id=task_id,
+        operator_type="PythonOperator",
+        estimated_seconds=seconds,
+        confidence=1.0,
+    )
+
+
+def _dag(edges: dict[str, list[str]]) -> SimpleNamespace:
+    """Build a fake DAG with ``task_dict``/``downstream_task_ids`` duck-typing.
+
+    ``edges`` maps a task_id to its downstream task_ids. Tasks referenced only as
+    downstreams are inferred so callers don't have to list every task twice.
+    """
+    referenced = set(edges) | {downstream for downstreams in edges.values() for downstream in downstreams}
+    task_dict = {
+        task_id: SimpleNamespace(
+            task_id=task_id,
+            downstream_task_ids=set(edges.get(task_id, [])),
+        )
+        for task_id in referenced
+    }
+    return SimpleNamespace(task_dict=task_dict)
+
+
+class TestEmptyAndTrivial:
+    def test_empty_task_responses_returns_empty_result(self):
+        result = get_critical_path(_dag({}), [])
+
+        assert result.critical_path == []
+        assert result.critical_edges == []
+        assert result.longest_task == ""
+
+    def test_single_task_is_its_own_path(self):
+        result = get_critical_path(_dag({"a": []}), [_task("a", 7)])
+
+        assert result.critical_path == ["a"]
+        assert result.critical_edges == []
+        assert result.longest_task == "a"
+
+
+class TestLinearChain:
+    def test_linear_chain_returns_full_path(self):
+        # a -> b -> c, runtimes 1, 2, 3
+        dag = _dag({"a": ["b"], "b": ["c"], "c": []})
+        tasks = [_task("a", 1), _task("b", 2), _task("c", 3)]
+
+        result = get_critical_path(dag, tasks)
+
+        assert result.critical_path == ["a", "b", "c"]
+        assert result.critical_edges == [("a", "b"), ("b", "c")]
+        assert result.longest_task == "c"
+
+    def test_linear_chain_longest_task_is_largest_on_path(self):
+        # middle node is largest, even though it isn't the terminal task
+        dag = _dag({"a": ["b"], "b": ["c"], "c": []})
+        tasks = [_task("a", 1), _task("b", 100), _task("c", 1)]
+
+        result = get_critical_path(dag, tasks)
+
+        assert result.critical_path == ["a", "b", "c"]
+        assert result.longest_task == "b"
+
+
+class TestBranchingAndConverging:
+    def test_parallel_branches_take_longer_branch(self):
+        # a -> b -> d  (b=10)
+        # a -> c -> d  (c=1)
+        # critical path must go through b, not c.
+        dag = _dag({"a": ["b", "c"], "b": ["d"], "c": ["d"], "d": []})
+        tasks = [_task("a", 1), _task("b", 10), _task("c", 1), _task("d", 1)]
+
+        result = get_critical_path(dag, tasks)
+
+        assert result.critical_path == ["a", "b", "d"]
+        assert result.critical_edges == [("a", "b"), ("b", "d")]
+
+    def test_parallel_branches_use_max_not_sum(self):
+        # If we summed instead of taking max, total would be 1+5+5+1=12.
+        # Correct longest path is 1+5+1=7.
+        dag = _dag({"a": ["b", "c"], "b": ["d"], "c": ["d"], "d": []})
+        tasks = [_task("a", 1), _task("b", 5), _task("c", 5), _task("d", 1)]
+
+        result = get_critical_path(dag, tasks)
+
+        assert len(result.critical_path) == 3  # not 4
+        assert result.critical_path[0] == "a"
+        assert result.critical_path[-1] == "d"
+
+    def test_converging_dag_picks_longest_predecessor(self):
+        # two roots feeding a single sink: a=10, b=1, both -> c
+        dag = _dag({"a": ["c"], "b": ["c"], "c": []})
+        tasks = [_task("a", 10), _task("b", 1), _task("c", 1)]
+
+        result = get_critical_path(dag, tasks)
+
+        assert result.critical_path == ["a", "c"]
+        assert result.longest_task == "a"
+
+
+class TestEdgesAndTieBreaking:
+    def test_critical_edges_are_consecutive_pairs_of_path(self):
+        dag = _dag({"a": ["b"], "b": ["c"], "c": ["d"], "d": []})
+        tasks = [_task("a", 1), _task("b", 1), _task("c", 1), _task("d", 1)]
+
+        result = get_critical_path(dag, tasks)
+
+        expected = list(zip(result.critical_path, result.critical_path[1:]))
+        assert result.critical_edges == expected
+
+    def test_tied_parallel_branches_resolve_deterministically(self):
+        # b and c are identical-runtime parallel branches feeding d.
+        # Two ties are at play:
+        #   - During pred propagation, the first predecessor to claim the max wins
+        #     (strict ``>``), and successors are walked in sorted order, so "b"
+        #     wins over "c" for d's predecessor.
+        #   - The final ``end_task`` tie-break is ``(longest_sum, estimates, task_id)``,
+        #     which only matters when multiple terminal tasks tie.
+        # Pinning current behavior so a regression here surfaces a deliberate change.
+        dag = _dag({"a": ["b", "c"], "b": ["d"], "c": ["d"], "d": []})
+        tasks = [_task("a", 1), _task("b", 5), _task("c", 5), _task("d", 1)]
+
+        result = get_critical_path(dag, tasks)
+
+        assert result.critical_path == ["a", "b", "d"]
+        # Importantly, repeated calls return the same path (no nondeterminism).
+        assert get_critical_path(dag, tasks).critical_path == result.critical_path
+
+
+class TestDefensiveCases:
+    def test_task_in_response_but_missing_from_dag_task_dict(self):
+        # "orphan" task is in the response set but not in the DAG; should be
+        # treated as an isolated node, not crash.
+        dag = _dag({"a": ["b"], "b": []})
+        tasks = [_task("a", 1), _task("b", 2), _task("orphan", 100)]
+
+        result = get_critical_path(dag, tasks)
+
+        # orphan has the highest standalone estimate, so it wins as a 1-node path
+        assert result.critical_path == ["orphan"]
+        assert result.longest_task == "orphan"
+
+    def test_dag_without_task_dict_attribute_treats_all_tasks_isolated(self):
+        # No `task_dict` attribute at all → no edges discovered.
+        bare_dag = SimpleNamespace()
+        tasks = [_task("a", 1), _task("b", 5), _task("c", 3)]
+
+        result = get_critical_path(bare_dag, tasks)
+
+        # With no edges, every task is its own component; longest single task wins.
+        assert result.critical_path == ["b"]
+        assert result.critical_edges == []
+        assert result.longest_task == "b"
+
+    def test_only_edges_within_response_set_are_used(self):
+        # DAG references a downstream that isn't in the response → that edge is dropped.
+        dag = _dag({"a": ["b", "ghost"], "b": []})
+        tasks = [_task("a", 1), _task("b", 2)]
+
+        result = get_critical_path(dag, tasks)
+
+        assert "ghost" not in result.critical_path
+        assert result.critical_path == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    ("edges", "runtimes", "expected_path"),
+    [
+        # linear
+        ({"a": ["b"], "b": []}, {"a": 1, "b": 2}, ["a", "b"]),
+        # diamond — top branch (b=5) longer than bottom (c=2)
+        (
+            {"a": ["b", "c"], "b": ["d"], "c": ["d"], "d": []},
+            {"a": 1, "b": 5, "c": 2, "d": 1},
+            ["a", "b", "d"],
+        ),
+        # 3-wide parallel — middle branch (m=10) longest
+        (
+            {"a": ["x", "m", "y"], "x": ["z"], "m": ["z"], "y": ["z"], "z": []},
+            {"a": 1, "x": 1, "m": 10, "y": 1, "z": 1},
+            ["a", "m", "z"],
+        ),
+    ],
+)
+def test_path_length_across_topologies(edges, runtimes, expected_path):
+    dag = _dag(edges)
+    tasks = [_task(tid, secs) for tid, secs in runtimes.items()]
+
+    result = get_critical_path(dag, tasks)
+
+    assert result.critical_path == expected_path

--- a/airflow-core/tests/unit/simulation/test_predictor_interface.py
+++ b/airflow-core/tests/unit/simulation/test_predictor_interface.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for ``DeterministicPredictor`` and the predictor interface contract.
+
+The deterministic predictor is the bottom of the fallback chain — it has no
+DB dependencies and returns a constant per operator type, so historical and
+similar-DAG predictors are tested elsewhere via mocks. This file pins the
+operator → seconds mapping, the confidence value, and the ``estimate_dag``
+aggregation contract that all predictors inherit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from airflow.simulation.predictor_interface import (
+    _DETERMINISTIC_CONFIDENCE,
+    _OPERATOR_RUNTIME_SECONDS,
+    DeterministicPredictor,
+    OperatorType,
+    PredictedOutcome,
+    PredictorInterface,
+    SimulationEstimate,
+    TaskRuntimeEstimate,
+)
+
+
+class TestDeterministicEstimateTask:
+    @pytest.fixture
+    def predictor(self) -> DeterministicPredictor:
+        return DeterministicPredictor()
+
+    @pytest.mark.parametrize(
+        ("operator_type", "expected_seconds"),
+        [
+            (OperatorType.PYTHON, 30),
+            (OperatorType.BASH, 10),
+            (OperatorType.MYSQL, 60),
+            (OperatorType.POSTGRES, 60),
+            (OperatorType.S3_KEY, 300),
+            (OperatorType.UNKNOWN, 30),
+        ],
+    )
+    def test_known_operator_returns_mapped_runtime(self, predictor, operator_type, expected_seconds):
+        estimate = predictor.estimate_task("t1", operator_type)
+
+        assert estimate.estimated_seconds == expected_seconds
+
+    def test_known_operator_table_matches_implementation_table(self, predictor):
+        # Guards against the public mapping silently drifting from the source-of-truth dict.
+        for operator_type, expected_seconds in _OPERATOR_RUNTIME_SECONDS.items():
+            estimate = predictor.estimate_task("t1", operator_type)
+            assert estimate.estimated_seconds == expected_seconds
+
+    def test_unknown_operator_falls_back_to_default(self, predictor):
+        estimate = predictor.estimate_task("t1", "TotallyMadeUpOperator")
+
+        # The implementation defaults to 30s for unmapped operator strings.
+        assert estimate.estimated_seconds == 30
+
+    def test_confidence_is_constant_heuristic_value(self, predictor):
+        estimate = predictor.estimate_task("t1", OperatorType.PYTHON)
+
+        assert estimate.confidence == _DETERMINISTIC_CONFIDENCE
+
+    @pytest.mark.parametrize(
+        "operator_type",
+        [OperatorType.PYTHON, OperatorType.BASH, OperatorType.UNKNOWN, "MysteryOperator"],
+    )
+    def test_confidence_is_within_unit_interval(self, predictor, operator_type):
+        estimate = predictor.estimate_task("t1", operator_type)
+
+        assert 0.0 <= estimate.confidence <= 1.0
+
+    def test_estimate_preserves_task_and_operator_metadata(self, predictor):
+        estimate = predictor.estimate_task("my_task", OperatorType.PYTHON)
+
+        assert estimate.task_id == "my_task"
+        assert estimate.operator_type == OperatorType.PYTHON
+
+    def test_context_is_accepted_but_ignored(self, predictor):
+        # Deterministic predictor takes ``context`` for interface parity but
+        # must not let context perturb the result.
+        without_ctx = predictor.estimate_task("t1", OperatorType.PYTHON)
+        with_ctx = predictor.estimate_task(
+            "t1", OperatorType.PYTHON, context={"run_history": [1, 2, 3], "input_bytes": 999}
+        )
+
+        assert without_ctx == with_ctx
+
+    def test_returns_task_runtime_estimate_dataclass(self, predictor):
+        estimate = predictor.estimate_task("t1", OperatorType.PYTHON)
+
+        assert isinstance(estimate, TaskRuntimeEstimate)
+
+
+class TestEstimateDagAggregation:
+    """``estimate_dag`` is final on the interface — every predictor inherits it."""
+
+    def test_total_equals_sum_of_task_estimates(self):
+        predictor = DeterministicPredictor()
+        tasks = [
+            {"task_id": "a", "operator_type": OperatorType.PYTHON},  # 30
+            {"task_id": "b", "operator_type": OperatorType.BASH},  # 10
+            {"task_id": "c", "operator_type": OperatorType.S3_KEY},  # 300
+        ]
+
+        estimate = predictor.estimate_dag("my_dag", tasks)
+
+        assert isinstance(estimate, SimulationEstimate)
+        assert estimate.dag_id == "my_dag"
+        assert estimate.total_task_seconds == 30 + 10 + 300
+        assert estimate.total_task_seconds == sum(e.estimated_seconds for e in estimate.task_estimates)
+
+    def test_predicted_outcome_defaults_to_success(self):
+        predictor = DeterministicPredictor()
+        estimate = predictor.estimate_dag("d", [{"task_id": "t", "operator_type": OperatorType.PYTHON}])
+
+        assert estimate.predicted_outcome is PredictedOutcome.SUCCESS
+
+    def test_empty_dag_yields_zero_total(self):
+        predictor = DeterministicPredictor()
+
+        estimate = predictor.estimate_dag("empty", [])
+
+        assert estimate.task_estimates == []
+        assert estimate.total_task_seconds == 0
+
+    def test_missing_operator_type_treated_as_unknown(self):
+        predictor = DeterministicPredictor()
+        # task entry omits "operator_type" entirely
+        tasks = [{"task_id": "t1"}]
+
+        estimate = predictor.estimate_dag("d", tasks)
+
+        # Falls back to OperatorType.UNKNOWN → 30s.
+        assert estimate.task_estimates[0].estimated_seconds == 30
+
+
+class TestInterfaceContract:
+    def test_deterministic_is_a_predictor(self):
+        assert isinstance(DeterministicPredictor(), PredictorInterface)
+
+    def test_abstract_predictor_cannot_be_instantiated(self):
+        with pytest.raises(TypeError):
+            PredictorInterface()  # type: ignore[abstract]

--- a/airflow-core/tests/unit/simulation/test_simulation_executor.py
+++ b/airflow-core/tests/unit/simulation/test_simulation_executor.py
@@ -1,0 +1,274 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for ``SimulationExecutor``.
+
+These tests stub the predictor and BaseExecutor side-effecting hooks
+(``success``, ``fail``, ``log_task_event``) so that pure dispatch and state
+management can be exercised without standing up Airflow infrastructure. The
+predictor itself is covered in ``test_predictor_interface``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from airflow.executors import workloads
+from airflow.simulation.predictor_interface import (
+    DeterministicPredictor,
+    PredictedOutcome,
+    TaskRuntimeEstimate,
+)
+from airflow.simulation.simulation_executor import SimulationExecutor
+
+
+def _fake_estimate() -> TaskRuntimeEstimate:
+    return TaskRuntimeEstimate(
+        task_id="t",
+        operator_type="PythonOperator",
+        estimated_seconds=42,
+        confidence=0.5,
+    )
+
+
+def _fake_task_workload(*, key="ti-key-1", predicted_outcome="success") -> SimpleNamespace:
+    """Build a ``ExecuteTask``-shaped duck-typed object.
+
+    Tests that exercise ``isinstance(workload, workloads.ExecuteTask)`` should
+    use ``Mock(spec=workloads.ExecuteTask)`` instead — see ``test_dispatch_*``.
+    """
+    return SimpleNamespace(
+        ti=SimpleNamespace(
+            key=key,
+            task_id="t",
+            dag_id="d",
+            run_id="r",
+            map_index=-1,
+            operator="PythonOperator",
+            predicted_outcome=predicted_outcome,
+        ),
+    )
+
+
+def _make_executor(*, predictor=None) -> SimulationExecutor:
+    """Build an executor with the side-effecting BaseExecutor hooks stubbed out."""
+    executor = SimulationExecutor(predictor=predictor or MagicMock(spec=DeterministicPredictor))
+    executor.success = MagicMock()
+    executor.fail = MagicMock()
+    executor.log_task_event = MagicMock()
+    return executor
+
+
+class TestInit:
+    def test_defaults_to_deterministic_predictor(self):
+        executor = SimulationExecutor()
+
+        assert isinstance(executor.predictor, DeterministicPredictor)
+
+    def test_accepts_custom_predictor(self):
+        predictor = MagicMock(spec=DeterministicPredictor)
+
+        executor = SimulationExecutor(predictor=predictor)
+
+        assert executor.predictor is predictor
+
+    def test_executor_flags(self):
+        executor = SimulationExecutor()
+
+        assert executor.is_local is True
+        assert executor.is_production is False
+        assert executor.supports_callbacks is True
+
+
+class TestProcessWorkloadsDispatch:
+    def test_task_workload_dispatched_to_task_handler(self):
+        executor = _make_executor()
+        executor._process_task_workload = MagicMock()
+        executor._process_callback_workload = MagicMock()
+        task_workload = Mock(spec=workloads.ExecuteTask)
+
+        executor._process_workloads([task_workload])
+
+        executor._process_task_workload.assert_called_once_with(task_workload)
+        executor._process_callback_workload.assert_not_called()
+
+    def test_callback_workload_dispatched_to_callback_handler(self):
+        executor = _make_executor()
+        executor._process_task_workload = MagicMock()
+        executor._process_callback_workload = MagicMock()
+        callback_workload = Mock(spec=workloads.ExecuteCallback)
+
+        executor._process_workloads([callback_workload])
+
+        executor._process_callback_workload.assert_called_once_with(callback_workload)
+        executor._process_task_workload.assert_not_called()
+
+    def test_unknown_workload_type_raises_value_error(self):
+        executor = _make_executor()
+        unknown_workload = SimpleNamespace()  # not ExecuteTask, not ExecuteCallback
+
+        with pytest.raises(ValueError, match="does not know how to handle"):
+            executor._process_workloads([unknown_workload])
+
+
+class TestProcessTaskWorkload:
+    def test_success_outcome_calls_success_with_info_dict(self):
+        predictor = MagicMock()
+        predictor.estimate_task.return_value = _fake_estimate()
+        executor = _make_executor(predictor=predictor)
+        workload = _fake_task_workload(predicted_outcome="success")
+        executor.queued_tasks[workload.ti.key] = "anything"  # simulate queued state
+
+        executor._process_task_workload(workload)
+
+        executor.success.assert_called_once()
+        executor.fail.assert_not_called()
+        info = executor.success.call_args.kwargs["info"]
+        assert info == {
+            "simulated": True,
+            "estimated_runtime": 42,
+            "confidence": 0.5,
+            "predicted_outcome": "success",
+        }
+        # State transitions: dequeued + added to running.
+        assert workload.ti.key not in executor.queued_tasks
+        assert workload.ti.key in executor.running
+
+    def test_failure_outcome_calls_fail(self):
+        predictor = MagicMock()
+        predictor.estimate_task.return_value = _fake_estimate()
+        executor = _make_executor(predictor=predictor)
+        workload = _fake_task_workload(predicted_outcome="failure")
+
+        executor._process_task_workload(workload)
+
+        executor.fail.assert_called_once()
+        executor.success.assert_not_called()
+        assert executor.fail.call_args.kwargs["info"]["predicted_outcome"] == "failure"
+
+    def test_unknown_outcome_treated_as_non_failure_so_success_is_called(self):
+        # Per ``_check_outcome``: anything that doesn't parse to FAILURE falls
+        # through to the success branch. Pin that contract.
+        predictor = MagicMock()
+        predictor.estimate_task.return_value = _fake_estimate()
+        executor = _make_executor(predictor=predictor)
+        workload = _fake_task_workload(predicted_outcome="garbage_value")
+
+        executor._process_task_workload(workload)
+
+        executor.success.assert_called_once()
+        executor.fail.assert_not_called()
+
+    def test_logs_simulation_event_with_predictor_metadata(self):
+        predictor = MagicMock()
+        predictor.estimate_task.return_value = _fake_estimate()
+        executor = _make_executor(predictor=predictor)
+        workload = _fake_task_workload()
+
+        executor._process_task_workload(workload)
+
+        executor.log_task_event.assert_called_once()
+        call = executor.log_task_event.call_args
+        assert call.kwargs["event"] == "simulation"
+        assert call.kwargs["ti_key"] == workload.ti.key
+        assert "estimated_runtime=42s" in call.kwargs["extra"]
+        assert "confidence=0.5" in call.kwargs["extra"]
+
+    def test_predictor_called_with_task_metadata(self):
+        predictor = MagicMock()
+        predictor.estimate_task.return_value = _fake_estimate()
+        executor = _make_executor(predictor=predictor)
+        workload = _fake_task_workload()
+
+        executor._process_task_workload(workload)
+
+        predictor.estimate_task.assert_called_once_with(
+            task_id=workload.ti.task_id,
+            operator_type=workload.ti.operator,
+            context={
+                "dag_id": workload.ti.dag_id,
+                "run_id": workload.ti.run_id,
+                "map_index": workload.ti.map_index,
+            },
+        )
+
+
+class TestProcessCallbackWorkload:
+    def test_callback_workload_marks_event_buffer_simulated_success(self):
+        executor = _make_executor()
+        callback_workload = SimpleNamespace(callback=SimpleNamespace(id="cb-1"))
+        executor.queued_callbacks["cb-1"] = "anything"
+
+        executor._process_callback_workload(callback_workload)
+
+        assert "cb-1" not in executor.queued_callbacks
+        # event_buffer is keyed by callback id.
+        from airflow.utils.state import CallbackState
+
+        assert executor.event_buffer["cb-1"] == (CallbackState.SUCCESS, {"simulated": True})
+
+
+class TestCheckOutcome:
+    @pytest.mark.parametrize(
+        ("input_value", "expected"),
+        [
+            (PredictedOutcome.SUCCESS, PredictedOutcome.SUCCESS),
+            (PredictedOutcome.FAILURE, PredictedOutcome.FAILURE),
+            ("success", PredictedOutcome.SUCCESS),
+            ("failure", PredictedOutcome.FAILURE),
+            ("unknown", PredictedOutcome.UNKNOWN),
+            ("not-a-real-outcome", PredictedOutcome.UNKNOWN),
+            (None, PredictedOutcome.UNKNOWN),
+            (42, PredictedOutcome.UNKNOWN),
+        ],
+    )
+    def test_check_outcome_normalization(self, input_value, expected):
+        assert SimulationExecutor._check_outcome(input_value) is expected
+
+
+class TestTerminateAndRevoke:
+    def test_terminate_clears_in_memory_state(self):
+        executor = _make_executor()
+        executor.queued_tasks["a"] = "x"
+        executor.queued_callbacks["b"] = "y"
+        executor.running.add("c")
+
+        executor.terminate()
+
+        assert executor.queued_tasks == {}
+        assert executor.queued_callbacks == {}
+        assert executor.running == set()
+
+    def test_revoke_task_removes_ti_from_queued_and_running(self):
+        executor = _make_executor()
+        ti = SimpleNamespace(key="ti-99")
+        executor.queued_tasks["ti-99"] = "x"
+        executor.running.add("ti-99")
+
+        executor.revoke_task(ti=ti)
+
+        assert "ti-99" not in executor.queued_tasks
+        assert "ti-99" not in executor.running
+
+    def test_revoke_task_is_idempotent_when_ti_not_present(self):
+        # Should not raise if the ti was never queued/running.
+        executor = _make_executor()
+        ti = SimpleNamespace(key="ghost")
+
+        executor.revoke_task(ti=ti)  # should not raise


### PR DESCRIPTION
  ---                                                                                                                   
  Testing: backfill unit tests for the DAG Simulation feature
                                                                                                                        
  Summary                                                   
                                                                                                                        
  This PR closes the test gaps the report flagged for Sprint 4 — critical path, bottleneck detector, and the            
  previously-untested simulation surface (predictor interface, executor, /simulate auth, UI display helpers, DB         
  migration). All work is unit-level; integration tests against seeded historical data are out of scope and tracked     
  separately.                                                                                                         
                                                                                                                      
  7 commits, +1,311 / −142 lines, 6 new test files, 2 test files extended.                                              
                                                                                                                        
  What's covered                                                                                                        
                                                                                                                      
  Area: Critical path                                                                                                   
  File: tests/unit/simulation/test_critical_path.py                                                                   
  Cases: 13                                                                                                             
  Notes: Linear, branching, converging, parallel-max, tie-break, missing-task defenses, parametrized topologies      
  ────────────────────────────────────────                                                                              
  Area: Bottleneck detector                                                                                             
  File: tests/unit/simulation/test_bottleneck.py                                                                      
  Cases: 5                                                                                                              
  Notes: Single-task, linear-chain max, off-path-not-bottleneck, tied tasks, empty input. Each asserts the bottleneck is
                                                                                                                      
    on-path                                                                                                             
  ────────────────────────────────────────                                                                            
  Area: DeterministicPredictor + interface                                                                            
  File: tests/unit/simulation/test_predictor_interface.py                                                               
  Cases: 22
  Notes: Operator → seconds map, confidence bounds, estimate_dag aggregation contract, abstract base contract           
  ────────────────────────────────────────                                                                            
  Area: SimulationExecutor                                                                                              
  File: tests/unit/simulation/test_simulation_executor.py
  Cases: 23                                                                                                             
  Notes: Workload dispatch, success/failure paths, log emission, _check_outcome normalization across all input types, 
    terminate/revoke_task cleanup. BaseExecutor side effects mocked                                                   
  ────────────────────────────────────────
  Area: /simulate endpoint                                                                                              
  File: tests/unit/api_fastapi/.../test_simulation.py (extended)
  Cases: +6                                                                                                             
  Notes: Result-cache regressions (UUID uniqueness, cross-DAG isolation), auth posture (401/403 on POST + GET),       
  tightened                                                                                                           
    run-listing assertion
  ────────────────────────────────────────
  Area: UI display helpers                                                                                              
  File: ui/src/utils/simulationDisplay.test.ts
  Cases: 12                                                                                                             
  Notes: Search-param parsing, critical-path filtering, max-duration bottleneck, metric labels, undefined-report      
    fallback, tie-breaking                                                                                            
  ────────────────────────────────────────
  Area: Migration metadata                                                                                              
  File: tests/unit/migrations/test_simulation_migration.py
  Cases: 6                                                                                                              
  Notes: Revision ids, down_revision chain, airflow_version stamp, callables. Full DB roundtrip is handled by Airflow's
    existing migration test chain                                                                                     

  Total: ~85 new test cases.                                                                                            
   
  Commit map                                                                                                            
                                                                                                                      
  add critical-path unit tests                                                                                        
  add bottleneck detector unit tests                                                                                    
  add SimulationExecutor unit tests
  add DeterministicPredictor and predictor-interface tests                                                              
  add /simulate auth, result-cache, and run-listing tests                                                               
  apply ruff-format to simulation feature files          ← format-only, no behavior                                   
  add vitest ui tests and migration metadata tests                                                                      
                                                                                                                      
  Not covered (intentionally — separate work)                                                                           
                                                                                                                      
  - Full Vitest component tests for Simulation.tsx, Graph.tsx, PanelButtons.tsx simulation overlays                     
  - Integration tests that seed historical DAG runs and assert /simulate returns history-derived (not heuristic)      
  estimates                                                                                                             
  - Real alembic upgrade/downgrade roundtrip on a temp sqlite DB (covered by Airflow's existing migration suite)      
  - SimilarDagPredictor is still a skeleton — no predictor logic to test yet                                            
  - User acceptance testing (depends on UI integration landing first)                                                   
                                                                                                                        
  How to run                                                                                                            
                                                                                                                        
  # Python tests                                                                                                      
  breeze run pytest airflow-core/tests/unit/simulation/ -xvs                                                          
  breeze run pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py -xvs                  
  breeze run pytest airflow-core/tests/unit/migrations/test_simulation_migration.py -xvs                                
                                                                                                                        
  # UI tests                                                                                                            
  cd airflow-core/src/airflow/ui && pnpm test simulationDisplay                                                       
                                                                                                                        
  Test plan                                                                                                           
                                                                                                                        
  - All new pytest files pass via breeze run pytest                                                                     
  - Vitest passes via pnpm test                                                                                       
  - prek run --from-ref feature --stage pre-commit passes (lint + ruff-format)                                          
  - No regressions in pre-existing tests on feature                                                                     
                                                                                                                      
  Known notes for reviewers                                                                                             
                                                                                                                      
  - Auth tests pin current behavior (POST gated by requires_access_dag(method="GET")). Tightening the gate to require   
  write permission is a deliberate future change that would require updating TestSimulationAccessControl.             
  - The result-cache tests document the in-memory _simulation_results dict's behavior. Migrating to per-DagRun          
  persistence is also a deliberate future change covered by those tests.                                                
  - SimulationExecutor tests stub BaseExecutor.success/fail/log_task_event so the suite needs no live Airflow         
  infrastructure.                                                                 