### PR TITLE
Success predict

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/simulation.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/simulation.py
@@ -26,6 +26,16 @@ class TaskSimulationResponse(BaseModel):
     operator_type: str
     estimated_seconds: int
     confidence: float
+    # Counts of historical (dag_id, task_id) entries the predictors used —
+    # same lookback window as the SuccessPredictor. ``historical_total`` is the
+    # number of records available; ``historical_success`` and
+    # ``historical_failed`` count the ``success`` and ``failed``/``upstream_failed``
+    # subsets. Other terminal states (``skipped``, ``removed``) are included in
+    # the total but not in either subset, so the two columns will not generally
+    # add up to the total.
+    historical_total: int = 0
+    historical_success: int = 0
+    historical_failed: int = 0
 
 
 class CriticalPathResult(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/simulation.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/simulation.py
@@ -45,3 +45,8 @@ class SimulationResponse(BaseModel):
     total_estimated_seconds: int
     critical_path: CriticalPathResult
     predicted_outcome: str
+    # Probability in [0.0, 1.0] that every task in the DAG would succeed,
+    # computed by SuccessPredictor from historical task-state data.
+    success_probability: float
+    # Per-task success probabilities keyed by task_id.
+    task_success_probabilities: dict[str, float]

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
@@ -36,6 +36,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance as TI
 from airflow.simulation.critical_path import get_critical_path
+from airflow.simulation.fingerprint import compute_task_fingerprint
 from airflow.simulation.predictors.historical_predictor import HistoricalPredictor
 from airflow.simulation.predictors.success_predictor import SuccessPredictor
 from airflow.utils.state import DagRunState
@@ -122,9 +123,22 @@ def run_simulation(
 
     historical_predictor = HistoricalPredictor()
     success_predictor = SuccessPredictor()
-    estimates = [
-        historical_predictor.estimate_task(t["task_id"], t["operator_type"]) for t in tasks
-    ]
+
+    # Compute a fingerprint per task so the runtime predictor can fall through
+    # to cross-DAG history of the same callable / bash command / SQL when the
+    # exact (dag_id, task_id) pair lacks enough history.
+    dag_task_dict = getattr(dag, "task_dict", {}) or {}
+    estimates = []
+    for t in tasks:
+        task_obj = dag_task_dict.get(t["task_id"])
+        fingerprint = compute_task_fingerprint(task_obj) if task_obj is not None else None
+        estimates.append(
+            historical_predictor.estimate_task(
+                t["task_id"],
+                t["operator_type"],
+                context={"dag_id": dag_id, "task_fingerprint": fingerprint},
+            )
+        )
 
     simulation_id = str(uuid.uuid4())
     task_responses = []

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
@@ -121,20 +121,28 @@ def run_simulation(
             )
 
     historical_predictor = HistoricalPredictor()
+    success_predictor = SuccessPredictor()
     estimates = [
         historical_predictor.estimate_task(t["task_id"], t["operator_type"]) for t in tasks
     ]
 
     simulation_id = str(uuid.uuid4())
-    task_responses = [
-        TaskSimulationResponse(
-            task_id=te.task_id,
-            operator_type=te.operator_type,
-            estimated_seconds=te.estimated_seconds,
-            confidence=te.confidence,
+    task_responses = []
+    for te in estimates:
+        total, success_count, failed_count = success_predictor.count_task_outcomes(
+            dag_id, te.task_id
         )
-        for te in estimates
-    ]
+        task_responses.append(
+            TaskSimulationResponse(
+                task_id=te.task_id,
+                operator_type=te.operator_type,
+                estimated_seconds=te.estimated_seconds,
+                confidence=te.confidence,
+                historical_total=total,
+                historical_success=success_count,
+                historical_failed=failed_count,
+            )
+        )
 
     critical_path_response = get_critical_path(dag, task_responses)
     # ``total_estimated_seconds`` reports the critical-path runtime — a true
@@ -146,7 +154,6 @@ def run_simulation(
         for task_id in critical_path_response.critical_path
     )
 
-    success_predictor = SuccessPredictor()
     dag_success_probability, task_success_probabilities = success_predictor.predict_dag_success(
         dag_id,
         [t["task_id"] for t in tasks],

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
@@ -21,6 +21,7 @@ import uuid
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
 
+from airflow._shared.timezones import timezone
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
@@ -35,11 +36,10 @@ from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance as TI
 from airflow.simulation.critical_path import get_critical_path
-from airflow.simulation.predictor_interface import DeterministicPredictor
 from airflow.simulation.predictors.historical_predictor import HistoricalPredictor
+from airflow.simulation.predictors.success_predictor import SuccessPredictor
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
-from airflow._shared.timezones import timezone
 
 simulation_router = AirflowRouter(tags=["Simulation"], prefix="/dags/{dag_id}")
 
@@ -144,13 +144,24 @@ def run_simulation(
 
     critical_path_response = get_critical_path(dag, task_responses)
 
+    success_predictor = SuccessPredictor()
+    dag_success_probability, task_success_probabilities = success_predictor.predict_dag_success(
+        dag_id,
+        [t["task_id"] for t in tasks],
+    )
+    # Derive a coarse pass/fail label from the probability so existing
+    # consumers of ``predicted_outcome`` keep working.
+    predicted_outcome = "success" if dag_success_probability >= 0.5 else "failure"
+
     response = SimulationResponse(
         simulation_id=simulation_id,
         dag_id=dag_id,
         task_estimates=task_responses,
         total_estimated_seconds=total_runtime,
-        critical_path=critical_path_response,  # bottle neck is returned in this function
-        predicted_outcome="success",  # TODO: replace with actual model prediction in the future implementation
+        critical_path=critical_path_response,
+        predicted_outcome=predicted_outcome,
+        success_probability=dag_success_probability,
+        task_success_probabilities=task_success_probabilities,
     )
 
     simulation_run_id = DagRunType.SIMULATION.generate_run_id(suffix=simulation_id)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/simulation.py
@@ -121,15 +121,9 @@ def run_simulation(
             )
 
     historical_predictor = HistoricalPredictor()
-    estimates = []
-    total_runtime = 0
-    for t in tasks:
-        task_runtime_estimate = historical_predictor.estimate_task(
-            t["task_id"],
-            t["operator_type"],
-        )
-        estimates.append(task_runtime_estimate)
-        total_runtime += task_runtime_estimate.estimated_seconds
+    estimates = [
+        historical_predictor.estimate_task(t["task_id"], t["operator_type"]) for t in tasks
+    ]
 
     simulation_id = str(uuid.uuid4())
     task_responses = [
@@ -143,6 +137,14 @@ def run_simulation(
     ]
 
     critical_path_response = get_critical_path(dag, task_responses)
+    # ``total_estimated_seconds`` reports the critical-path runtime — a true
+    # lower bound on wall-clock execution when tasks parallelize. Summing every
+    # task's runtime would double-count parallel branches and over-estimate.
+    estimated_seconds_by_task_id = {te.task_id: te.estimated_seconds for te in estimates}
+    total_runtime = sum(
+        estimated_seconds_by_task_id[task_id]
+        for task_id in critical_path_response.critical_path
+    )
 
     success_predictor = SuccessPredictor()
     dag_success_probability, task_success_probabilities = success_predictor.predict_dag_success(

--- a/airflow-core/src/airflow/simulation/data/historical_data_extractor.py
+++ b/airflow-core/src/airflow/simulation/data/historical_data_extractor.py
@@ -23,10 +23,12 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 
 from airflow.models.dagrun import DagRun
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance
+from airflow.simulation.fingerprint import compute_task_fingerprint
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 
@@ -310,3 +312,114 @@ def get_dag_run_state_history(
     rows = session.execute(stmt).all()
 
     return [row.state for row in rows]
+
+
+def _find_matching_task_pairs(
+    fingerprint: str,
+    *,
+    session: Session,
+) -> list[tuple[str, str]]:
+    """
+    Walk every serialized DAG and return ``(dag_id, task_id)`` pairs whose
+    task fingerprints match the input.
+
+    This is intentionally O(serialized_dags × tasks_per_dag) — fast enough for
+    a single ``/simulate`` call against a fork-sized metadata DB. A production
+    deployment would denormalize fingerprints onto ``task_instance`` to avoid
+    walking the JSON every time.
+    """
+    pairs: list[tuple[str, str]] = []
+    serialized_dags = session.scalars(select(SerializedDagModel)).all()
+    for sdm in serialized_dags:
+        try:
+            dag = sdm.dag
+        except Exception:
+            # A serialized DAG that fails to materialize is a deployment
+            # problem, not a simulation problem — skip it rather than poison
+            # the whole prediction.
+            continue
+        for task in dag.tasks:
+            if compute_task_fingerprint(task) == fingerprint:
+                pairs.append((sdm.dag_id, task.task_id))
+    return pairs
+
+
+@provide_session
+def get_historical_runtimes_by_fingerprint(
+    fingerprint: str,
+    *,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    states: list[str] | None = None,
+    exclude_simulations: bool = True,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+    session: Session = NEW_SESSION,
+) -> list[HistoricalRuntime]:
+    """
+    Retrieve historical runtimes for tasks with a matching cross-DAG fingerprint.
+
+    Used by :class:`HistoricalPredictor` as the second-tier fallback: when an
+    exact ``(dag_id, task_id)`` match has insufficient history but the same
+    operator + work signal exists elsewhere in the metadata DB, those records
+    feed the runtime estimate. Confidence is graded lower than exact match.
+
+    Args:
+        fingerprint: Stable identity hash (see :func:`compute_task_fingerprint`).
+        start_date: Only include runs that started on or after this datetime.
+        end_date: Only include runs that started on or before this datetime.
+        states: Task states to include. Defaults to ``["success"]`` when *None*.
+        exclude_simulations: When *True*, exclude rows where ``is_simulation`` is set.
+        limit: Maximum number of records to return. Capped at :data:`DEFAULT_LIMIT`.
+        offset: Number of records to skip for pagination.
+        session: SQLAlchemy session (provided by ``@provide_session``).
+
+    Returns:
+        A list of :class:`HistoricalRuntime` records ordered by ``start_date``
+        descending. Empty when no DAGs in the metadata DB carry a matching
+        fingerprint, or when none of those tasks have run yet.
+    """
+    if states is None:
+        states = [TaskInstanceState.SUCCESS.value]
+
+    limit = min(max(limit, 1), DEFAULT_LIMIT)
+    offset = max(offset, 0)
+
+    pairs = _find_matching_task_pairs(fingerprint, session=session)
+    if not pairs:
+        return []
+
+    stmt = select(
+        TaskInstance.run_id,
+        TaskInstance.duration,
+        TaskInstance.start_date,
+        TaskInstance.end_date,
+        TaskInstance.state,
+    ).where(
+        tuple_(TaskInstance.dag_id, TaskInstance.task_id).in_(pairs),
+        TaskInstance.state.in_(states),
+    )
+
+    if start_date is not None:
+        stmt = stmt.where(TaskInstance.start_date >= start_date)
+
+    if end_date is not None:
+        stmt = stmt.where(TaskInstance.start_date <= end_date)
+
+    if exclude_simulations and hasattr(TaskInstance, "is_simulation"):
+        stmt = stmt.where(TaskInstance.is_simulation.is_(False))
+
+    stmt = stmt.order_by(TaskInstance.start_date.desc()).limit(limit).offset(offset)
+
+    rows = session.execute(stmt).all()
+
+    return [
+        HistoricalRuntime(
+            run_id=row.run_id,
+            duration=row.duration,
+            start_date=row.start_date,
+            end_date=row.end_date,
+            state=row.state,
+        )
+        for row in rows
+    ]

--- a/airflow-core/src/airflow/simulation/data/historical_data_extractor.py
+++ b/airflow-core/src/airflow/simulation/data/historical_data_extractor.py
@@ -25,6 +25,7 @@ from uuid import UUID
 
 from sqlalchemy import select
 
+from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
@@ -252,6 +253,59 @@ def get_task_state_history(
         stmt = stmt.where(TaskInstance.is_simulation.is_(False))
 
     stmt = stmt.order_by(TaskInstance.start_date.desc()).limit(limit)
+
+    rows = session.execute(stmt).all()
+
+    return [row.state for row in rows]
+
+
+@provide_session
+def get_dag_run_state_history(
+    dag_id: str,
+    *,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    exclude_simulations: bool = True,
+    limit: int = DEFAULT_LIMIT,
+    session: Session = NEW_SESSION,
+) -> list[str]:
+    """
+    Return DagRun states for a DAG, ordered newest-first.
+
+    Used by :class:`SuccessPredictor` for DAG-level success prediction. Returns
+    every recorded DagRun state (``success``, ``failed``, ...). Unlike per-task
+    state queries, only terminal DagRun outcomes are meaningful here, so
+    in-flight states (``running``, ``queued``) are filtered out.
+
+    Args:
+        dag_id: The DAG identifier.
+        start_date: Only include runs that started on or after this datetime.
+        end_date: Only include runs that started on or before this datetime.
+        exclude_simulations: When *True*, exclude DagRuns flagged as simulations.
+        limit: Maximum number of records to return. Capped at :data:`DEFAULT_LIMIT`.
+        session: SQLAlchemy session (provided by ``@provide_session``).
+
+    Returns:
+        A list of state strings ordered by ``start_date`` descending (most
+        recent first).
+    """
+    limit = min(max(limit, 1), DEFAULT_LIMIT)
+
+    stmt = select(DagRun.state, DagRun.start_date).where(
+        DagRun.dag_id == dag_id,
+        DagRun.state.in_(("success", "failed")),
+    )
+
+    if start_date is not None:
+        stmt = stmt.where(DagRun.start_date >= start_date)
+
+    if end_date is not None:
+        stmt = stmt.where(DagRun.start_date <= end_date)
+
+    if exclude_simulations and hasattr(DagRun, "is_simulation"):
+        stmt = stmt.where(DagRun.is_simulation.is_(False))
+
+    stmt = stmt.order_by(DagRun.start_date.desc()).limit(limit)
 
     rows = session.execute(stmt).all()
 

--- a/airflow-core/src/airflow/simulation/data/historical_data_extractor.py
+++ b/airflow-core/src/airflow/simulation/data/historical_data_extractor.py
@@ -140,7 +140,8 @@ def get_historical_runtimes_by_operator(
     offset: int = 0,
     session: Session = NEW_SESSION,
 ) -> list[HistoricalRuntime]:
-    """Retrieve historical runtimes for all tasks using a given operator type.
+    """
+    Retrieve historical runtimes for all tasks using a given operator type.
 
     This enables cross-DAG estimates for new tasks that have no history of
     their own but share an operator type with tasks that do.
@@ -200,3 +201,58 @@ def get_historical_runtimes_by_operator(
         )
         for row in rows
     ]
+
+
+@provide_session
+def get_task_state_history(
+    dag_id: str,
+    task_id: str,
+    *,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    exclude_simulations: bool = True,
+    limit: int = DEFAULT_LIMIT,
+    session: Session = NEW_SESSION,
+) -> list[str]:
+    """
+    Return task instance states for a task, ordered newest-first.
+
+    Unlike :func:`get_historical_runtimes`, this does not filter by state — every
+    recorded outcome (``success``, ``failed``, ``upstream_failed``, ``skipped``,
+    etc.) is returned. Used by :class:`SuccessPredictor` to compute success rates.
+
+    Args:
+        dag_id: The DAG identifier.
+        task_id: The task identifier.
+        start_date: Only include runs that started on or after this datetime.
+        end_date: Only include runs that started on or before this datetime.
+        exclude_simulations: When *True*, exclude rows where ``is_simulation`` is set.
+        limit: Maximum number of records to return. Capped at :data:`DEFAULT_LIMIT`.
+        session: SQLAlchemy session (provided by ``@provide_session``).
+
+    Returns:
+        A list of state strings ordered by ``start_date`` descending (most
+        recent first). ``None`` states are filtered out.
+    """
+    limit = min(max(limit, 1), DEFAULT_LIMIT)
+
+    stmt = select(TaskInstance.state, TaskInstance.start_date).where(
+        TaskInstance.dag_id == dag_id,
+        TaskInstance.task_id == task_id,
+        TaskInstance.state.is_not(None),
+    )
+
+    if start_date is not None:
+        stmt = stmt.where(TaskInstance.start_date >= start_date)
+
+    if end_date is not None:
+        stmt = stmt.where(TaskInstance.start_date <= end_date)
+
+    if exclude_simulations and hasattr(TaskInstance, "is_simulation"):
+        stmt = stmt.where(TaskInstance.is_simulation.is_(False))
+
+    stmt = stmt.order_by(TaskInstance.start_date.desc()).limit(limit)
+
+    rows = session.execute(stmt).all()
+
+    return [row.state for row in rows]

--- a/airflow-core/src/airflow/simulation/fingerprint.py
+++ b/airflow-core/src/airflow/simulation/fingerprint.py
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Cross-DAG task identity ("fingerprint").
+
+Two task instances in different DAGs are considered "the same task" — and
+therefore valid donors of historical runtime data — when their operator class
+and operator-specific work signal hash to the same value.
+
+Fingerprints intentionally exclude ``dag_id``, ``task_id``, and DAG-positional
+metadata: those identify a task's *location*, not its *behavior*. Matching by
+operator-class alone would already be the existing Level 3 fallback in
+``HistoricalPredictor``; the fingerprint adds finer-grained signals — the
+Python callable, the bash command, the SQL query — that distinguish two
+tasks that share an operator type but do completely different work.
+
+A fingerprint of ``None`` means the task offered no signal beyond its operator
+class. Callers should skip the fingerprint level in that case so the predictor
+falls through to the operator-type fallback.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
+def _python_callable_signal(task: Any) -> str | None:
+    callable_obj = getattr(task, "python_callable", None)
+    if callable_obj is None:
+        return None
+    module = getattr(callable_obj, "__module__", None)
+    qualname = getattr(callable_obj, "__qualname__", getattr(callable_obj, "__name__", None))
+    if module is None and qualname is None:
+        return None
+    return f"py:{module or '?'}.{qualname or '?'}"
+
+
+def _bash_command_signal(task: Any) -> str | None:
+    command = getattr(task, "bash_command", None)
+    if not command or not isinstance(command, str):
+        return None
+    return f"bash:{_hash(command)}"
+
+
+def _sql_signal(task: Any) -> str | None:
+    sql = getattr(task, "sql", None)
+    if not sql:
+        return None
+    text = sql if isinstance(sql, str) else str(sql)
+    return f"sql:{_hash(text)}"
+
+
+def _image_signal(task: Any) -> str | None:
+    image = getattr(task, "image", None)
+    if not image or not isinstance(image, str):
+        return None
+    return f"img:{image}"
+
+
+# The signal extractors are tried in turn; any that return a non-None value
+# contribute to the fingerprint. Order is stable so the resulting hash is
+# deterministic across processes and across Airflow restarts.
+_SIGNAL_EXTRACTORS = (
+    _python_callable_signal,
+    _bash_command_signal,
+    _sql_signal,
+    _image_signal,
+)
+
+
+def compute_task_fingerprint(task: Any) -> str | None:
+    """
+    Return a stable identity for a task across DAGs, or ``None`` if no signal exists.
+
+    A fingerprint of ``None`` signals to the predictor that the operator class
+    is the only available signal — equivalent to falling back to the operator
+    fallback level rather than running an expensive cross-DAG search that
+    would yield the same result.
+    """
+    operator_class = type(task).__name__
+    parts: list[str] = [operator_class]
+
+    for extract in _SIGNAL_EXTRACTORS:
+        signal = extract(task)
+        if signal is not None:
+            parts.append(signal)
+
+    # If the only part is the operator class name, the fingerprint adds no
+    # information beyond what the operator-type fallback already provides.
+    if len(parts) == 1:
+        return None
+
+    return _hash("|".join(parts))

--- a/airflow-core/src/airflow/simulation/predictors/historical_predictor.py
+++ b/airflow-core/src/airflow/simulation/predictors/historical_predictor.py
@@ -24,6 +24,7 @@ from enum import Enum
 
 from airflow.simulation.data.historical_data_extractor import (
     get_historical_runtimes,
+    get_historical_runtimes_by_fingerprint,
     get_historical_runtimes_by_operator,
 )
 from airflow.simulation.predictor_interface import (
@@ -36,6 +37,13 @@ from airflow.simulation.predictor_interface import (
 _HISTORICAL_BASE_CONFIDENCE: float = 0.7
 # Maximum confidence ceiling.
 _HISTORICAL_MAX_CONFIDENCE: float = 0.95
+# Confidence range for cross-DAG fingerprint matches — same operator + same
+# work signal (callable, bash command, SQL). Sits between exact match and the
+# operator-only fallback because the work signal is finer-grained than
+# operator class alone but still less specific than a same-(dag_id, task_id)
+# match.
+_FINGERPRINT_BASE_CONFIDENCE: float = 0.6
+_FINGERPRINT_MAX_CONFIDENCE: float = 0.85
 # Confidence range for operator-type cross-DAG estimates (lower than exact match).
 _OPERATOR_BASE_CONFIDENCE: float = 0.55
 _OPERATOR_MAX_CONFIDENCE: float = 0.75
@@ -64,7 +72,8 @@ def _percentile(data: list[float], pct: float) -> float:
 
 
 def _filter_outliers(durations: list[float], num_mad: float = 3.0) -> list[float]:
-    """Remove outliers using the median absolute deviation (MAD).
+    """
+    Remove outliers using the median absolute deviation (MAD).
 
     Unlike mean/stdev, the median and MAD are robust to outliers — a
     single extreme value cannot inflate the spread enough to hide itself.
@@ -104,7 +113,8 @@ def _compute_confidence(
     base: float = _HISTORICAL_BASE_CONFIDENCE,
     ceiling: float = _HISTORICAL_MAX_CONFIDENCE,
 ) -> float:
-    """Scale confidence based on how many data points were used.
+    """
+    Scale confidence based on how many data points were used.
 
     More data points → higher confidence, capped at *ceiling*.
 
@@ -118,7 +128,8 @@ def _compute_confidence(
 
 
 class HistoricalPredictor(PredictorInterface):
-    """Predicts task runtime from historical execution data.
+    """
+    Predicts task runtime from historical execution data.
 
     Falls back to :class:`DeterministicPredictor` when insufficient
     history is available.
@@ -180,7 +191,30 @@ class HistoricalPredictor(PredictorInterface):
                 confidence=_compute_confidence(len(durations)),
             )
 
-        # --- Level 2: operator-type match (same operator across all DAGs) ---
+        # --- Level 2: cross-DAG fingerprint match (same operator + same work
+        # signal — Python callable, bash command, SQL — across all DAGs) ---
+        fingerprint = (context or {}).get("task_fingerprint")
+        if fingerprint:
+            fp_runtimes = get_historical_runtimes_by_fingerprint(
+                fingerprint,
+                start_date=start_date,
+                limit=self.max_runs,
+            )
+            fp_durations = self._extract_durations(fp_runtimes)
+
+            if fp_durations is not None:
+                return TaskRuntimeEstimate(
+                    task_id=task_id,
+                    operator_type=operator_type,
+                    estimated_seconds=int(round(_aggregate(fp_durations, self.aggregation))),
+                    confidence=_compute_confidence(
+                        len(fp_durations),
+                        base=_FINGERPRINT_BASE_CONFIDENCE,
+                        ceiling=_FINGERPRINT_MAX_CONFIDENCE,
+                    ),
+                )
+
+        # --- Level 3: operator-type match (same operator across all DAGs) ---
         operator_runtimes = get_historical_runtimes_by_operator(
             operator_type,
             start_date=start_date,
@@ -200,11 +234,12 @@ class HistoricalPredictor(PredictorInterface):
                 ),
             )
 
-        # --- Level 3: hardcoded heuristic ---
+        # --- Level 4: hardcoded heuristic ---
         return self._fallback.estimate_task(task_id, operator_type, context)
 
     def _extract_durations(self, runtimes: list) -> list[float] | None:
-        """Extract valid durations and apply outlier filtering.
+        """
+        Extract valid durations and apply outlier filtering.
 
         Returns a list of durations if enough data points remain after
         filtering, or ``None`` to signal that the caller should try the

--- a/airflow-core/src/airflow/simulation/predictors/success_predictor.py
+++ b/airflow-core/src/airflow/simulation/predictors/success_predictor.py
@@ -22,11 +22,21 @@ import math
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 
-from airflow.simulation.data.historical_data_extractor import get_task_state_history
+from airflow.simulation.data.historical_data_extractor import (
+    get_dag_run_state_history,
+    get_task_state_history,
+)
 
-# Only ``success`` counts as a success outcome — everything else (failed,
-# upstream_failed, skipped, ...) reduces the probability.
-_SUCCESS_STATE: str = "success"
+# Per-task success states. ``skipped`` and ``removed`` indicate the DAG ran
+# normally — branching logic chose another path or the task was removed from
+# the DAG since the run was created. Treating them as failures would make
+# branching DAGs always score very low.
+_TASK_SUCCESS_STATES: frozenset[str] = frozenset({"success", "skipped", "removed"})
+
+# DAG-level success states. Only a fully-successful run counts; ``failed``
+# is a clear failure, and in-flight states (``running``, ``queued``) are
+# filtered upstream by the extractor.
+_DAG_SUCCESS_STATES: frozenset[str] = frozenset({"success"})
 
 _DEFAULT_LOOKBACK_DAYS: int = 30
 _DEFAULT_MAX_RUNS: int = 100
@@ -65,12 +75,22 @@ def _compute_weights(
     return [1.0] * num_runs
 
 
-def _weighted_success_rate(states: list[str], weights: list[float]) -> float:
-    """Compute the weighted fraction of states equal to ``success``."""
+def _weighted_success_rate(
+    states: list[str],
+    weights: list[float],
+    success_states: frozenset[str],
+) -> float:
+    """
+    Compute the weighted fraction of states that count as success.
+
+    ``success_states`` lets callers distinguish between per-task success
+    semantics (``skipped`` counts) and DAG-level semantics (only ``success``
+    counts).
+    """
     total = sum(weights)
     if total <= 0:
         return 0.0
-    success = sum(weight for state, weight in zip(states, weights) if state == _SUCCESS_STATE)
+    success = sum(weight for state, weight in zip(states, weights) if state in success_states)
     return success / total
 
 
@@ -78,11 +98,12 @@ class SuccessPredictor:
     """
     Predict success probability for tasks and DAGs from historical state data.
 
-    The probability is computed as the (optionally weighted) fraction of
-    historical runs in the ``success`` state. DAG-level probability assumes
-    independent task outcomes — ``P(DAG) = product(P(task_i))`` — which is
-    conservative; correlated failure modes (e.g. shared upstream) make the
-    real DAG-level probability higher.
+    Per-task probability is the (optionally weighted) fraction of historical
+    TaskInstance runs that ended in a non-failure state — ``success``,
+    ``skipped``, or ``removed``. DAG-level probability is computed
+    independently from historical ``DagRun.state`` values (success vs failed),
+    not by multiplying per-task probabilities — this matches "did the run
+    finish in SUCCESS" and avoids geometric decay across many tasks.
 
     When fewer than ``min_runs`` historical executions exist, the predictor
     returns ``default_probability`` (0.5 by default — a neutral signal).
@@ -118,16 +139,23 @@ class SuccessPredictor:
         self.weighting = weighting
         self.decay_lambda = decay_lambda
 
-    def predict_task_success(self, dag_id: str, task_id: str) -> float:
-        """Return the success probability for a single task in ``[0.0, 1.0]``."""
-        start_date = None
-        if self.lookback_days is not None:
-            start_date = datetime.now(tz=timezone.utc) - timedelta(days=self.lookback_days)
+    def _start_date(self) -> datetime | None:
+        if self.lookback_days is None:
+            return None
+        return datetime.now(tz=timezone.utc) - timedelta(days=self.lookback_days)
 
+    def predict_task_success(self, dag_id: str, task_id: str) -> float:
+        """
+        Return the success probability for a single task in ``[0.0, 1.0]``.
+
+        Treats ``skipped`` and ``removed`` states as success — they indicate
+        the DAG ran normally (e.g. branching steered around the task) and
+        should not lower the task's score.
+        """
         states = get_task_state_history(
             dag_id,
             task_id,
-            start_date=start_date,
+            start_date=self._start_date(),
             limit=self.max_runs,
         )
 
@@ -135,7 +163,28 @@ class SuccessPredictor:
             return self.default_probability
 
         weights = _compute_weights(len(states), self.weighting, self.decay_lambda)
-        return _weighted_success_rate(states, weights)
+        return _weighted_success_rate(states, weights, _TASK_SUCCESS_STATES)
+
+    def predict_dag_success_rate(self, dag_id: str) -> float:
+        """
+        Return the DAG-level success probability in ``[0.0, 1.0]``.
+
+        Computed from historical ``DagRun.state`` values rather than by
+        multiplying per-task probabilities. This matches the user's actual
+        question ("did the run finish in SUCCESS?") and avoids geometric
+        decay from independent-task multiplication.
+        """
+        states = get_dag_run_state_history(
+            dag_id,
+            start_date=self._start_date(),
+            limit=self.max_runs,
+        )
+
+        if len(states) < self.min_runs:
+            return self.default_probability
+
+        weights = _compute_weights(len(states), self.weighting, self.decay_lambda)
+        return _weighted_success_rate(states, weights, _DAG_SUCCESS_STATES)
 
     def predict_dag_success(
         self,
@@ -145,15 +194,13 @@ class SuccessPredictor:
         """
         Return ``(dag_probability, per_task_probabilities)``.
 
-        Each task's probability is computed independently; the DAG-level
-        probability is the product, treating tasks as independent. Returns
-        ``(default_probability, {})`` when ``task_ids`` is empty.
+        DAG probability comes from :meth:`predict_dag_success_rate` (DagRun
+        history). Per-task probabilities are computed independently from
+        :meth:`predict_task_success` and exposed for the UI table — they no
+        longer feed into the DAG-level number.
         """
-        if not task_ids:
-            return self.default_probability, {}
-
         per_task = {
             task_id: self.predict_task_success(dag_id, task_id) for task_id in task_ids
         }
-        dag_probability = math.prod(per_task.values())
+        dag_probability = self.predict_dag_success_rate(dag_id)
         return dag_probability, per_task

--- a/airflow-core/src/airflow/simulation/predictors/success_predictor.py
+++ b/airflow-core/src/airflow/simulation/predictors/success_predictor.py
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Historical success-rate predictor for tasks and DAGs."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+
+from airflow.simulation.data.historical_data_extractor import get_task_state_history
+
+# Only ``success`` counts as a success outcome — everything else (failed,
+# upstream_failed, skipped, ...) reduces the probability.
+_SUCCESS_STATE: str = "success"
+
+_DEFAULT_LOOKBACK_DAYS: int = 30
+_DEFAULT_MAX_RUNS: int = 100
+_DEFAULT_MIN_RUNS: int = 3
+_DEFAULT_PROBABILITY: float = 0.5
+_DEFAULT_DECAY_LAMBDA: float = 0.1
+
+
+class WeightingMethod(str, Enum):
+    """How to weight historical runs by recency."""
+
+    NONE = "none"
+    LINEAR = "linear"
+    EXPONENTIAL = "exponential"
+
+
+def _compute_weights(
+    num_runs: int,
+    method: WeightingMethod,
+    decay_lambda: float,
+) -> list[float]:
+    """
+    Return weights for runs ordered newest-first.
+
+    Index 0 is the most recent run; higher indices are older. Newer runs
+    receive equal-or-greater weight than older runs.
+    """
+    if num_runs <= 0:
+        return []
+    if method == WeightingMethod.LINEAR:
+        # Newest gets weight num_runs, oldest gets weight 1.
+        return [float(num_runs - i) for i in range(num_runs)]
+    if method == WeightingMethod.EXPONENTIAL:
+        return [math.exp(-decay_lambda * i) for i in range(num_runs)]
+    # WeightingMethod.NONE — uniform weights.
+    return [1.0] * num_runs
+
+
+def _weighted_success_rate(states: list[str], weights: list[float]) -> float:
+    """Compute the weighted fraction of states equal to ``success``."""
+    total = sum(weights)
+    if total <= 0:
+        return 0.0
+    success = sum(weight for state, weight in zip(states, weights) if state == _SUCCESS_STATE)
+    return success / total
+
+
+class SuccessPredictor:
+    """
+    Predict success probability for tasks and DAGs from historical state data.
+
+    The probability is computed as the (optionally weighted) fraction of
+    historical runs in the ``success`` state. DAG-level probability assumes
+    independent task outcomes — ``P(DAG) = product(P(task_i))`` — which is
+    conservative; correlated failure modes (e.g. shared upstream) make the
+    real DAG-level probability higher.
+
+    When fewer than ``min_runs`` historical executions exist, the predictor
+    returns ``default_probability`` (0.5 by default — a neutral signal).
+
+    Args:
+        lookback_days: Only consider runs from the last *lookback_days* days.
+            ``None`` disables the time filter.
+        max_runs: Maximum number of recent runs to fetch per task.
+        min_runs: Minimum runs required to compute a probability from data.
+        default_probability: Returned when insufficient history exists. Must
+            be in ``[0.0, 1.0]``.
+        weighting: How to weight runs by recency. Defaults to ``NONE``.
+        decay_lambda: Decay rate for exponential weighting. Ignored for
+            other weighting modes.
+    """
+
+    def __init__(
+        self,
+        *,
+        lookback_days: int | None = _DEFAULT_LOOKBACK_DAYS,
+        max_runs: int = _DEFAULT_MAX_RUNS,
+        min_runs: int = _DEFAULT_MIN_RUNS,
+        default_probability: float = _DEFAULT_PROBABILITY,
+        weighting: WeightingMethod = WeightingMethod.NONE,
+        decay_lambda: float = _DEFAULT_DECAY_LAMBDA,
+    ) -> None:
+        if not 0.0 <= default_probability <= 1.0:
+            raise ValueError("default_probability must be in [0.0, 1.0]")
+        self.lookback_days = lookback_days
+        self.max_runs = max_runs
+        self.min_runs = max(min_runs, 1)
+        self.default_probability = default_probability
+        self.weighting = weighting
+        self.decay_lambda = decay_lambda
+
+    def predict_task_success(self, dag_id: str, task_id: str) -> float:
+        """Return the success probability for a single task in ``[0.0, 1.0]``."""
+        start_date = None
+        if self.lookback_days is not None:
+            start_date = datetime.now(tz=timezone.utc) - timedelta(days=self.lookback_days)
+
+        states = get_task_state_history(
+            dag_id,
+            task_id,
+            start_date=start_date,
+            limit=self.max_runs,
+        )
+
+        if len(states) < self.min_runs:
+            return self.default_probability
+
+        weights = _compute_weights(len(states), self.weighting, self.decay_lambda)
+        return _weighted_success_rate(states, weights)
+
+    def predict_dag_success(
+        self,
+        dag_id: str,
+        task_ids: list[str],
+    ) -> tuple[float, dict[str, float]]:
+        """
+        Return ``(dag_probability, per_task_probabilities)``.
+
+        Each task's probability is computed independently; the DAG-level
+        probability is the product, treating tasks as independent. Returns
+        ``(default_probability, {})`` when ``task_ids`` is empty.
+        """
+        if not task_ids:
+            return self.default_probability, {}
+
+        per_task = {
+            task_id: self.predict_task_success(dag_id, task_id) for task_id in task_ids
+        }
+        dag_probability = math.prod(per_task.values())
+        return dag_probability, per_task

--- a/airflow-core/src/airflow/simulation/predictors/success_predictor.py
+++ b/airflow-core/src/airflow/simulation/predictors/success_predictor.py
@@ -186,6 +186,27 @@ class SuccessPredictor:
         weights = _compute_weights(len(states), self.weighting, self.decay_lambda)
         return _weighted_success_rate(states, weights, _DAG_SUCCESS_STATES)
 
+    def count_task_outcomes(self, dag_id: str, task_id: str) -> tuple[int, int, int]:
+        """
+        Return ``(total, success, failed)`` counts of historical task instances.
+
+        Uses the same lookback window and limit as :meth:`predict_task_success`,
+        so the counts reflect exactly the data the predictor sees. ``failed``
+        counts both ``failed`` and ``upstream_failed`` states; the difference
+        between ``total`` and ``success + failed`` is made up of other
+        terminal states (``skipped``, ``removed``).
+        """
+        states = get_task_state_history(
+            dag_id,
+            task_id,
+            start_date=self._start_date(),
+            limit=self.max_runs,
+        )
+        total = len(states)
+        success = sum(1 for state in states if state == "success")
+        failed = sum(1 for state in states if state in {"failed", "upstream_failed"})
+        return total, success, failed
+
     def predict_dag_success(
         self,
         dag_id: str,

--- a/airflow-core/src/airflow/ui/src/components/ExpandableMenu/Menu.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ExpandableMenu/Menu.tsx
@@ -12,7 +12,7 @@ export const SimulationMenu = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const options = getSimulationDisplayOptions(searchParams);
 
-  const toggle = (key: "sim_cp" | "sim_duration") => {
+  const toggle = (key: "sim_cp" | "sim_duration" | "sim_success") => {
     const nextSearchParams = new URLSearchParams(searchParams);
     const isEnabled = nextSearchParams.get(key) === "1";
 
@@ -67,6 +67,20 @@ export const SimulationMenu = () => {
                   <ChakraCheckbox.Label>Bottlenecks - Run Time</ChakraCheckbox.Label>
                   <Text fontSize="xs" color="gray.600" fontWeight="normal">
                     Display Tasks with the Highest Expected Run Time
+                  </Text>
+                </VStack>
+              </ChakraCheckbox.Root>
+
+              <ChakraCheckbox.Root
+                checked={options.showSuccessProbability}
+                onCheckedChange={() => toggle("sim_success")}
+              >
+                <ChakraCheckbox.HiddenInput />
+                <ChakraCheckbox.Control />
+                <VStack align="start" gap={0}>
+                  <ChakraCheckbox.Label>Success Probability</ChakraCheckbox.Label>
+                  <Text fontSize="xs" color="gray.600" fontWeight="normal">
+                    Display Per-Task Success Likelihood from Historical Runs
                   </Text>
                 </VStack>
               </ChakraCheckbox.Root>

--- a/airflow-core/src/airflow/ui/src/pages/Simulation/Simulation.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Simulation/Simulation.tsx
@@ -22,6 +22,12 @@ interface TaskEstimate {
   operator_type: string;
   estimated_seconds: number;
   confidence: number;
+  // Counts of historical (dag_id, task_id) entries the predictors saw —
+  // total, success-state count, failed-state count (failed + upstream_failed).
+  // Optional because older simulation reports won't include them.
+  historical_total?: number;
+  historical_success?: number;
+  historical_failed?: number;
 }
 
 interface CriticalPathResult {
@@ -228,11 +234,19 @@ export const Simulation = () => {
                     <Table.ColumnHeader>Estimated Seconds</Table.ColumnHeader>
                     <Table.ColumnHeader>Confidence</Table.ColumnHeader>
                     <Table.ColumnHeader>Success Probability</Table.ColumnHeader>
+                    <Table.ColumnHeader>History (Total)</Table.ColumnHeader>
+                    <Table.ColumnHeader>Succeeded</Table.ColumnHeader>
+                    <Table.ColumnHeader>Failed</Table.ColumnHeader>
                   </Table.Row>
                 </Table.Header>
                 <Table.Body>
                   {report.task_estimates.map((taskEstimate) => {
                     const probability = report.task_success_probabilities?.[taskEstimate.task_id];
+                    // History columns render "—" when there is zero same-(dag_id,
+                    // task_id) data — the predictor fell back to operator-type
+                    // history or the deterministic heuristic.
+                    const total = taskEstimate.historical_total ?? 0;
+                    const hasHistory = total > 0;
 
                     return (
                       <Table.Row key={taskEstimate.task_id}>
@@ -242,6 +256,13 @@ export const Simulation = () => {
                         <Table.Cell>{(taskEstimate.confidence * 100).toFixed(0)}%</Table.Cell>
                         <Table.Cell>
                           {probability === undefined ? "—" : formatProbabilityPercent(probability)}
+                        </Table.Cell>
+                        <Table.Cell>{hasHistory ? total : "—"}</Table.Cell>
+                        <Table.Cell>
+                          {hasHistory ? (taskEstimate.historical_success ?? 0) : "—"}
+                        </Table.Cell>
+                        <Table.Cell>
+                          {hasHistory ? (taskEstimate.historical_failed ?? 0) : "—"}
                         </Table.Cell>
                       </Table.Row>
                     );

--- a/airflow-core/src/airflow/ui/src/pages/Simulation/Simulation.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Simulation/Simulation.tsx
@@ -15,6 +15,7 @@ import { FiClock } from "react-icons/fi";
 import { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { useDagServiceGetDagDetails } from "openapi/queries";
+import { formatProbabilityPercent } from "src/utils/simulationDisplay";
 
 interface TaskEstimate {
   task_id: string;
@@ -36,6 +37,10 @@ interface SimulationReport {
   total_estimated_seconds: number;
   critical_path: CriticalPathResult;
   predicted_outcome: string;
+  // Optional because reports persisted before the SuccessPredictor backend
+  // landed will not include them.
+  success_probability?: number;
+  task_success_probabilities?: Record<string, number>;
 }
 
 const getLatestSimulationId = (dagId: string): string | null => {
@@ -181,6 +186,16 @@ export const Simulation = () => {
                   </Text>
                 </HStack>
               </GridItem>
+              {report.success_probability !== undefined ? (
+                <GridItem>
+                  <Text fontSize="sm" fontWeight="medium" color="fg.muted">
+                    DAG Success Probability
+                  </Text>
+                  <Text fontSize="lg" fontWeight="bold" mt={1}>
+                    {formatProbabilityPercent(report.success_probability)}
+                  </Text>
+                </GridItem>
+              ) : null}
               <GridItem>
                 <Text fontSize="sm" fontWeight="medium" color="fg.muted">
                   Task Count
@@ -212,17 +227,25 @@ export const Simulation = () => {
                     <Table.ColumnHeader>Operator</Table.ColumnHeader>
                     <Table.ColumnHeader>Estimated Seconds</Table.ColumnHeader>
                     <Table.ColumnHeader>Confidence</Table.ColumnHeader>
+                    <Table.ColumnHeader>Success Probability</Table.ColumnHeader>
                   </Table.Row>
                 </Table.Header>
                 <Table.Body>
-                  {report.task_estimates.map((taskEstimate) => (
-                    <Table.Row key={taskEstimate.task_id}>
-                      <Table.Cell>{taskEstimate.task_id}</Table.Cell>
-                      <Table.Cell>{taskEstimate.operator_type}</Table.Cell>
-                      <Table.Cell>{taskEstimate.estimated_seconds}</Table.Cell>
-                      <Table.Cell>{(taskEstimate.confidence * 100).toFixed(0)}%</Table.Cell>
-                    </Table.Row>
-                  ))}
+                  {report.task_estimates.map((taskEstimate) => {
+                    const probability = report.task_success_probabilities?.[taskEstimate.task_id];
+
+                    return (
+                      <Table.Row key={taskEstimate.task_id}>
+                        <Table.Cell>{taskEstimate.task_id}</Table.Cell>
+                        <Table.Cell>{taskEstimate.operator_type}</Table.Cell>
+                        <Table.Cell>{taskEstimate.estimated_seconds}</Table.Cell>
+                        <Table.Cell>{(taskEstimate.confidence * 100).toFixed(0)}%</Table.Cell>
+                        <Table.Cell>
+                          {probability === undefined ? "—" : formatProbabilityPercent(probability)}
+                        </Table.Cell>
+                      </Table.Row>
+                    );
+                  })}
                 </Table.Body>
               </Table.Root>
             </Box>

--- a/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
@@ -41,6 +41,7 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { isStatePending, useAutoRefresh } from "src/utils";
+import { formatProbabilityPercent } from "src/utils/simulationDisplay";
 
 const defaultHour = "24";
 
@@ -49,6 +50,11 @@ interface SimulationTaskEstimate {
   operator_type: string;
   estimated_seconds: number;
   confidence: number;
+  // Per-task success probability in [0.0, 1.0]. Populated by the fetch helper
+  // from the report's ``task_success_probabilities`` map. Optional because
+  // reports persisted before the SuccessPredictor backend landed will not
+  // include it.
+  success_probability?: number;
 }
 
 type LatestSimulationRecord = {
@@ -75,6 +81,7 @@ const getLatestSimulationRecord = (dagId: string): LatestSimulationRecord | null
 
 interface SimulationReport {
   task_estimates: SimulationTaskEstimate[];
+  task_success_probabilities?: Record<string, number>;
 }
 
 const fetchSimulationTaskEstimate = async (
@@ -96,7 +103,15 @@ const fetchSimulationTaskEstimate = async (
   }
 
   const data = (await response.json()) as SimulationReport;
-  return data.task_estimates.find((estimate) => estimate.task_id === taskId) ?? null;
+  const estimate = data.task_estimates.find((te) => te.task_id === taskId);
+  if (estimate === undefined) {
+    return null;
+  }
+
+  return {
+    ...estimate,
+    success_probability: data.task_success_probabilities?.[taskId],
+  };
 };
 
 export const Overview = () => {
@@ -232,6 +247,16 @@ export const Overview = () => {
                   </Text>
                   <Text fontSize="lg" fontWeight="bold">
                     {(simulationTask.confidence * 100).toFixed(0)}%
+                  </Text>
+                </GridItem>
+                <GridItem>
+                  <Text fontSize="sm" fontWeight="medium" color="fg.muted">
+                    Success Probability
+                  </Text>
+                  <Text fontSize="lg" fontWeight="bold">
+                    {simulationTask.success_probability === undefined
+                      ? "—"
+                      : formatProbabilityPercent(simulationTask.success_probability)}
                   </Text>
                 </GridItem>
               </Grid>

--- a/airflow-core/src/airflow/ui/src/utils/simulationDisplay.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/simulationDisplay.test.ts
@@ -19,6 +19,7 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  formatProbabilityPercent,
   getSimulationDisplayOptions,
   getSimulationTaskDisplayMetadata,
   type SimulationReportLike,
@@ -40,12 +41,13 @@ const makeReport = (
 });
 
 describe("getSimulationDisplayOptions", () => {
-  it("returns both flags false when no params are set", () => {
+  it("returns all flags false when no params are set", () => {
     const params = new URLSearchParams();
 
     expect(getSimulationDisplayOptions(params)).toEqual({
       showCriticalPath: false,
       showDurationBottleneck: false,
+      showSuccessProbability: false,
     });
   });
 
@@ -61,13 +63,35 @@ describe("getSimulationDisplayOptions", () => {
     expect(getSimulationDisplayOptions(params).showDurationBottleneck).toBe(true);
   });
 
+  it("treats sim_success=1 as enabling success-probability overlay", () => {
+    const params = new URLSearchParams("sim_success=1");
+
+    expect(getSimulationDisplayOptions(params).showSuccessProbability).toBe(true);
+  });
+
   it("does not enable a flag for non-'1' truthy-looking values", () => {
-    const params = new URLSearchParams("sim_cp=true&sim_duration=yes");
+    const params = new URLSearchParams(
+      "sim_cp=true&sim_duration=yes&sim_success=on",
+    );
 
     expect(getSimulationDisplayOptions(params)).toEqual({
       showCriticalPath: false,
       showDurationBottleneck: false,
+      showSuccessProbability: false,
     });
+  });
+});
+
+describe("formatProbabilityPercent", () => {
+  it("formats whole numbers with one decimal place", () => {
+    expect(formatProbabilityPercent(0.75)).toBe("75.0%");
+    expect(formatProbabilityPercent(1)).toBe("100.0%");
+    expect(formatProbabilityPercent(0)).toBe("0.0%");
+  });
+
+  it("rounds to one decimal place", () => {
+    expect(formatProbabilityPercent(0.12345)).toBe("12.3%");
+    expect(formatProbabilityPercent(0.6789)).toBe("67.9%");
   });
 });
 
@@ -77,7 +101,7 @@ describe("getSimulationTaskDisplayMetadata", () => {
   it("returns no critical-path or bottleneck signals when both flags are off", () => {
     const result = getSimulationTaskDisplayMetadata(
       taskIds,
-      { showCriticalPath: false, showDurationBottleneck: false },
+      { showCriticalPath: false, showDurationBottleneck: false, showSuccessProbability: false },
       undefined,
       makeReport(),
     );
@@ -88,13 +112,14 @@ describe("getSimulationTaskDisplayMetadata", () => {
         isCriticalPath: false,
         metricLabel: undefined,
       });
+
     }
   });
 
   it("flags critical-path tasks when showCriticalPath is on", () => {
     const result = getSimulationTaskDisplayMetadata(
       taskIds,
-      { showCriticalPath: true, showDurationBottleneck: false },
+      { showCriticalPath: true, showDurationBottleneck: false, showSuccessProbability: false },
       undefined,
       makeReport(),
     );
@@ -108,7 +133,7 @@ describe("getSimulationTaskDisplayMetadata", () => {
     // Report says ["x", "a"] is the critical path, but "x" isn't in taskIds.
     const result = getSimulationTaskDisplayMetadata(
       ["a", "b"],
-      { showCriticalPath: true, showDurationBottleneck: false },
+      { showCriticalPath: true, showDurationBottleneck: false, showSuccessProbability: false },
       undefined,
       makeReport({
         critical_path: { critical_path: ["x", "a"], longest_task: "x" },
@@ -122,7 +147,7 @@ describe("getSimulationTaskDisplayMetadata", () => {
   it("marks the highest-duration task as the bottleneck when showDurationBottleneck is on", () => {
     const result = getSimulationTaskDisplayMetadata(
       taskIds,
-      { showCriticalPath: false, showDurationBottleneck: true },
+      { showCriticalPath: false, showDurationBottleneck: true, showSuccessProbability: false },
       undefined,
       makeReport(),
     );
@@ -136,13 +161,13 @@ describe("getSimulationTaskDisplayMetadata", () => {
   it("attaches a duration metric label only when bottleneck overlay is on", () => {
     const withFlag = getSimulationTaskDisplayMetadata(
       taskIds,
-      { showCriticalPath: false, showDurationBottleneck: true },
+      { showCriticalPath: false, showDurationBottleneck: true, showSuccessProbability: false },
       undefined,
       makeReport(),
     );
     const withoutFlag = getSimulationTaskDisplayMetadata(
       taskIds,
-      { showCriticalPath: false, showDurationBottleneck: false },
+      { showCriticalPath: false, showDurationBottleneck: false, showSuccessProbability: false },
       undefined,
       makeReport(),
     );
@@ -152,10 +177,64 @@ describe("getSimulationTaskDisplayMetadata", () => {
     expect(withoutFlag.a?.metricLabel).toBeUndefined();
   });
 
+  it("attaches a success probability label only when success overlay is on", () => {
+    const reportWithProbabilities = makeReport({
+      task_success_probabilities: { a: 0.9, b: 0.5, c: 0.1 },
+    });
+    const withFlag = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: false, showDurationBottleneck: false, showSuccessProbability: true },
+      undefined,
+      reportWithProbabilities,
+    );
+    const withoutFlag = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: false, showDurationBottleneck: false, showSuccessProbability: false },
+      undefined,
+      reportWithProbabilities,
+    );
+
+    expect(withFlag.a?.metricLabel).toBe("Success: 90.0%");
+    expect(withFlag.b?.metricLabel).toBe("Success: 50.0%");
+    expect(withFlag.c?.metricLabel).toBe("Success: 10.0%");
+    expect(withoutFlag.a?.metricLabel).toBeUndefined();
+  });
+
+  it("combines duration and success labels with a separator", () => {
+    const reportWithProbabilities = makeReport({
+      task_success_probabilities: { a: 0.9, b: 0.5, c: 0.1 },
+    });
+    const result = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: false, showDurationBottleneck: true, showSuccessProbability: true },
+      undefined,
+      reportWithProbabilities,
+    );
+
+    expect(result.a?.metricLabel).toBe("Dur: 5s | Success: 90.0%");
+  });
+
+  it("omits a success label when no probability is available for the task", () => {
+    // The report knows about "a" but not "b" or "c"; only "a" should get a label.
+    const reportWithProbabilities = makeReport({
+      task_success_probabilities: { a: 0.42 },
+    });
+    const result = getSimulationTaskDisplayMetadata(
+      taskIds,
+      { showCriticalPath: false, showDurationBottleneck: false, showSuccessProbability: true },
+      undefined,
+      reportWithProbabilities,
+    );
+
+    expect(result.a?.metricLabel).toBe("Success: 42.0%");
+    expect(result.b?.metricLabel).toBeUndefined();
+    expect(result.c?.metricLabel).toBeUndefined();
+  });
+
   it("returns no bottleneck and no labels when the report is undefined", () => {
     const result = getSimulationTaskDisplayMetadata(
       taskIds,
-      { showCriticalPath: true, showDurationBottleneck: true },
+      { showCriticalPath: true, showDurationBottleneck: true, showSuccessProbability: false },
       undefined,
       undefined,
     );
@@ -166,6 +245,7 @@ describe("getSimulationTaskDisplayMetadata", () => {
         isCriticalPath: false,
         metricLabel: undefined,
       });
+
     }
   });
 
@@ -173,7 +253,7 @@ describe("getSimulationTaskDisplayMetadata", () => {
     // "ghost" is in the report but not in the taskIds list — must not appear in metadata.
     const result = getSimulationTaskDisplayMetadata(
       ["a", "b"],
-      { showCriticalPath: false, showDurationBottleneck: true },
+      { showCriticalPath: false, showDurationBottleneck: true, showSuccessProbability: false },
       undefined,
       {
         task_estimates: [
@@ -196,7 +276,7 @@ describe("getSimulationTaskDisplayMetadata", () => {
     // the max keeps it — "a" wins because it appears first in the taskIds array.
     const result = getSimulationTaskDisplayMetadata(
       ["a", "b"],
-      { showCriticalPath: false, showDurationBottleneck: true },
+      { showCriticalPath: false, showDurationBottleneck: true, showSuccessProbability: false },
       undefined,
       {
         task_estimates: [

--- a/airflow-core/src/airflow/ui/src/utils/simulationDisplay.ts
+++ b/airflow-core/src/airflow/ui/src/utils/simulationDisplay.ts
@@ -1,6 +1,7 @@
 export type SimulationDisplayOptions = {
   showCriticalPath: boolean;
   showDurationBottleneck: boolean;
+  showSuccessProbability: boolean;
 };
 
 export type SimulationTaskDisplayMetadata = {
@@ -22,7 +23,17 @@ export type SimulationCriticalPath = {
 export type SimulationReportLike = {
   task_estimates: Array<SimulationTaskEstimate>;
   critical_path: SimulationCriticalPath;
+  // Per-task success probability in [0.0, 1.0], keyed by task_id. Optional
+  // because reports produced before the SuccessPredictor backend landed will
+  // not include it.
+  task_success_probabilities?: Record<string, number>;
+  // DAG-level success probability in [0.0, 1.0]. Optional for the same reason.
+  success_probability?: number;
 };
+
+// Format a probability in [0.0, 1.0] as a one-decimal percentage string.
+export const formatProbabilityPercent = (probability: number): string =>
+  `${(probability * 100).toFixed(1)}%`;
 
 type SimulationEdge = {
   source: string;
@@ -42,6 +53,7 @@ const getEstimatedSecondsByTaskId = (
 export const getSimulationDisplayOptions = (searchParams: URLSearchParams): SimulationDisplayOptions => ({
   showCriticalPath: searchParams.get("sim_cp") === "1",
   showDurationBottleneck: searchParams.get("sim_duration") === "1",
+  showSuccessProbability: searchParams.get("sim_success") === "1",
 });
 
 const getCriticalPathTaskIds = (
@@ -98,6 +110,13 @@ const getMetricLabel = (
     const estimatedSeconds = estimatedSecondsByTaskId.get(taskId);
     if (estimatedSeconds !== undefined) {
       labels.push(`Dur: ${estimatedSeconds}s`);
+    }
+  }
+
+  if (options.showSuccessProbability) {
+    const probability = simulationReport?.task_success_probabilities?.[taskId];
+    if (probability !== undefined) {
+      labels.push(`Success: ${formatProbabilityPercent(probability)}`);
     }
   }
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
@@ -118,14 +118,20 @@ class TestRunSimulation(TestSimulationEndpoint):
         assert isinstance(data["task_estimates"], list)
         assert len(data["task_estimates"]) > 0
 
-    def test_total_equals_sum_of_task_estimates(self, test_client, session):
+    def test_total_equals_sum_along_critical_path(self, test_client, session):
+        # ``total_estimated_seconds`` is the critical-path runtime — a true
+        # lower bound on wall-clock execution under parallelism — not the
+        # serial sum of every task's estimate.
         self.create_dag_run_with_tasks(session)
 
         response = test_client.post(f"/dags/{DAG_ID}/simulate")
 
         data = response.json()
-        total = sum(te["estimated_seconds"] for te in data["task_estimates"])
-        assert data["total_estimated_seconds"] == total
+        estimates_by_id = {te["task_id"]: te["estimated_seconds"] for te in data["task_estimates"]}
+        expected = sum(
+            estimates_by_id[task_id] for task_id in data["critical_path"]["critical_path"]
+        )
+        assert data["total_estimated_seconds"] == expected
 
     def test_should_load_serialized_dag_when_dag_run_dag_is_missing(self, test_client, session):
         self.create_dag_run_with_tasks(session)
@@ -272,28 +278,35 @@ class TestSuccessPredictorIntegration(TestSimulationEndpoint):
     not a hardcoded value.
     """
 
-    def _seed_history(self, session, *, dag_id, task_id, states):
+    def _seed_history(self, session, *, dag_id, task_id, states, dag_run_states=None):
         """Insert one TaskInstance per state in *states* under separate DagRuns.
 
-        Each TI is given a distinct ``start_date`` so the predictor's
-        newest-first ordering is well-defined.
+        ``dag_run_states`` (optional) lets the caller decouple per-task state
+        from DagRun state — useful for the branching scenario where a task is
+        ``skipped`` but the surrounding DagRun ended in SUCCESS. When omitted,
+        the DagRun state mirrors the task state (success → SUCCESS, anything
+        else → FAILED).
         """
         from datetime import timedelta
 
         dag = self.dagbag.get_latest_version_of_dag(dag_id, session=session)
         dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
-        # Find the source task on the DAG to construct TIs.
         source_task = next(t for t in dag.tasks if t.task_id == task_id)
 
         for index, state in enumerate(states):
             run_id = f"HISTORY_{task_id}_{index}"
             run_date = DEFAULT_TIME + timedelta(days=index)
+            dr_state = (
+                DagRunState(dag_run_states[index])
+                if dag_run_states is not None
+                else (DagRunState.SUCCESS if state == "success" else DagRunState.FAILED)
+            )
             dr = DagRun(
                 run_id=run_id,
                 dag_id=dag_id,
                 logical_date=run_date,
                 run_type=DagRunType.MANUAL,
-                state=DagRunState.SUCCESS if state == "success" else DagRunState.FAILED,
+                state=dr_state,
             )
             session.add(dr)
             session.flush()
@@ -361,3 +374,65 @@ class TestSuccessPredictorIntegration(TestSimulationEndpoint):
             if task_id == target_task_id:
                 continue
             assert prob == pytest.approx(0.5)
+
+    def test_dag_probability_uses_dag_run_history_not_task_multiplication(
+        self, test_client, session
+    ):
+        # Regression test: the old implementation multiplied per-task
+        # probabilities, so a DAG with N tasks and no history would score
+        # ``0.5^N`` and predict failure. The fix uses DagRun history
+        # directly. With the seeded 3 SUCCESS + 1 FAILED DagRuns, the
+        # DAG-level probability should be ~0.75 regardless of task count.
+        self.create_dag_run_with_tasks(session)
+        dag = self.dagbag.get_latest_version_of_dag(DAG_ID, session=session)
+        target_task_id = dag.tasks[0].task_id
+
+        self._seed_history(
+            session,
+            dag_id=DAG_ID,
+            task_id=target_task_id,
+            states=["success", "success", "success", "failed"],
+        )
+
+        response = test_client.post(f"/dags/{DAG_ID}/simulate")
+
+        data = response.json()
+        # 3 of 4 seeded DagRuns are SUCCESS (the helper mirrors task state
+        # to DagRun state), so DAG-level should be ~0.75.
+        assert data["success_probability"] == pytest.approx(0.75)
+        assert data["predicted_outcome"] == "success"
+
+    def test_branching_dag_with_skipped_tasks_does_not_predict_failure(
+        self, test_client, session
+    ):
+        # Bug regression: example_branch_operator_decorator (and any branching
+        # DAG) routinely produces ``state="skipped"`` for branched-around
+        # tasks. The old code treated skipped as failure and multiplied
+        # per-task probabilities, so any branching DAG predicted failure.
+        # The fix counts skipped as task-level success and reads DAG-level
+        # probability from DagRun history (not from task-prob multiplication).
+        self.create_dag_run_with_tasks(session)
+        dag = self.dagbag.get_latest_version_of_dag(DAG_ID, session=session)
+        target_task_id = dag.tasks[0].task_id
+
+        # Simulate a task that's been skipped on most past runs (typical for
+        # a branched-around task) but the DAG itself succeeded each time.
+        self._seed_history(
+            session,
+            dag_id=DAG_ID,
+            task_id=target_task_id,
+            states=["success", "skipped", "skipped", "skipped", "skipped"],
+            dag_run_states=["success"] * 5,
+        )
+
+        response = test_client.post(f"/dags/{DAG_ID}/simulate")
+
+        data = response.json()
+        # The branched-around task scores 1.0 (all skipped + 1 success
+        # count as task-level success).
+        assert data["task_success_probabilities"][target_task_id] == pytest.approx(1.0)
+        # The DAG-level number reflects DagRun history (all 5 runs were
+        # marked SUCCESS by the helper) so the prediction is success, not
+        # failure.
+        assert data["success_probability"] == pytest.approx(1.0)
+        assert data["predicted_outcome"] == "success"

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
@@ -402,6 +402,37 @@ class TestSuccessPredictorIntegration(TestSimulationEndpoint):
         assert data["success_probability"] == pytest.approx(0.75)
         assert data["predicted_outcome"] == "success"
 
+    def test_response_includes_per_task_history_counts(self, test_client, session):
+        # Seed a known mix of states so we can pin the count fields end-to-end.
+        self.create_dag_run_with_tasks(session)
+        dag = self.dagbag.get_latest_version_of_dag(DAG_ID, session=session)
+        target_task_id = dag.tasks[0].task_id
+
+        # 2 success, 1 failed, 1 upstream_failed, 1 skipped → counts should be:
+        # total=5, success=2, failed=2 (failed + upstream_failed), and skipped is in total only.
+        self._seed_history(
+            session,
+            dag_id=DAG_ID,
+            task_id=target_task_id,
+            states=["success", "success", "failed", "upstream_failed", "skipped"],
+        )
+
+        response = test_client.post(f"/dags/{DAG_ID}/simulate")
+        data = response.json()
+        target = next(te for te in data["task_estimates"] if te["task_id"] == target_task_id)
+
+        assert target["historical_total"] == 5
+        assert target["historical_success"] == 2
+        assert target["historical_failed"] == 2
+
+        # Other tasks have no seeded history → all zeros.
+        for te in data["task_estimates"]:
+            if te["task_id"] == target_task_id:
+                continue
+            assert te["historical_total"] == 0
+            assert te["historical_success"] == 0
+            assert te["historical_failed"] == 0
+
     def test_branching_dag_with_skipped_tasks_does_not_predict_failure(
         self, test_client, session
     ):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_simulation.py
@@ -143,7 +143,6 @@ class TestRunSimulation(TestSimulationEndpoint):
 
         post_response = test_client.post(f"/dags/{DAG_ID}/simulate")
         assert post_response.status_code == 200
-        simulation_id = post_response.json()["simulation_id"]
 
         dag_runs_response = test_client.get(f"/dags/{DAG_ID}/dagRuns?run_type=simulation")
         assert dag_runs_response.status_code == 200
@@ -263,3 +262,102 @@ class TestSimulationAccessControl(TestSimulationEndpoint):
         response = unauthorized_test_client.get(f"/dags/{DAG_ID}/simulate/any-id")
 
         assert response.status_code == 403
+
+
+class TestSuccessPredictorIntegration(TestSimulationEndpoint):
+    """End-to-end test: seeded historical task states feed the predictor.
+
+    Verifies that ``success_probability`` and ``task_success_probabilities``
+    in the API response reflect the historical state distribution we seeded,
+    not a hardcoded value.
+    """
+
+    def _seed_history(self, session, *, dag_id, task_id, states):
+        """Insert one TaskInstance per state in *states* under separate DagRuns.
+
+        Each TI is given a distinct ``start_date`` so the predictor's
+        newest-first ordering is well-defined.
+        """
+        from datetime import timedelta
+
+        dag = self.dagbag.get_latest_version_of_dag(dag_id, session=session)
+        dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
+        # Find the source task on the DAG to construct TIs.
+        source_task = next(t for t in dag.tasks if t.task_id == task_id)
+
+        for index, state in enumerate(states):
+            run_id = f"HISTORY_{task_id}_{index}"
+            run_date = DEFAULT_TIME + timedelta(days=index)
+            dr = DagRun(
+                run_id=run_id,
+                dag_id=dag_id,
+                logical_date=run_date,
+                run_type=DagRunType.MANUAL,
+                state=DagRunState.SUCCESS if state == "success" else DagRunState.FAILED,
+            )
+            session.add(dr)
+            session.flush()
+
+            ti = TaskInstance(
+                task=source_task,
+                state=state,
+                map_index=-1,
+                dag_version_id=dag_version.id,
+            )
+            ti.dag_run = dr
+            ti.start_date = run_date
+            ti.end_date = run_date + timedelta(seconds=10)
+            session.add(ti)
+
+        session.commit()
+
+    def test_response_includes_success_probability_fields(self, test_client, session):
+        self.create_dag_run_with_tasks(session)
+
+        response = test_client.post(f"/dags/{DAG_ID}/simulate")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "success_probability" in data
+        assert "task_success_probabilities" in data
+        assert 0.0 <= data["success_probability"] <= 1.0
+        for prob in data["task_success_probabilities"].values():
+            assert 0.0 <= prob <= 1.0
+
+    def test_no_history_returns_default_probability(self, test_client, session):
+        # Only the trigger DagRun exists (no historical runs); every task
+        # falls below min_runs and gets the default 0.5 probability.
+        self.create_dag_run_with_tasks(session)
+
+        response = test_client.post(f"/dags/{DAG_ID}/simulate")
+
+        data = response.json()
+        # Per-task probabilities should all be 0.5 (default) given no history.
+        for prob in data["task_success_probabilities"].values():
+            assert prob == pytest.approx(0.5)
+
+    def test_seeded_history_drives_per_task_probability(self, test_client, session):
+        # Seed 3 successes + 1 failure for one task → expect ~0.75 for that task.
+        self.create_dag_run_with_tasks(session)
+        # The example_python_operator DAG has known task ids; pick a real one.
+        dag = self.dagbag.get_latest_version_of_dag(DAG_ID, session=session)
+        target_task_id = dag.tasks[0].task_id
+
+        self._seed_history(
+            session,
+            dag_id=DAG_ID,
+            task_id=target_task_id,
+            states=["success", "success", "success", "failed"],
+        )
+
+        response = test_client.post(f"/dags/{DAG_ID}/simulate")
+
+        assert response.status_code == 200
+        data = response.json()
+        per_task = data["task_success_probabilities"]
+        assert per_task[target_task_id] == pytest.approx(0.75)
+        # Other tasks have no seeded history → still default 0.5.
+        for task_id, prob in per_task.items():
+            if task_id == target_task_id:
+                continue
+            assert prob == pytest.approx(0.5)

--- a/airflow-core/tests/unit/simulation/predictors/test_historical_predictor.py
+++ b/airflow-core/tests/unit/simulation/predictors/test_historical_predictor.py
@@ -25,15 +25,15 @@ import pytest
 
 from airflow.simulation.data.historical_data_extractor import HistoricalRuntime
 from airflow.simulation.predictor_interface import (
-    OperatorType,
     _DETERMINISTIC_CONFIDENCE,
     _OPERATOR_RUNTIME_SECONDS,
+    OperatorType,
 )
 from airflow.simulation.predictors.historical_predictor import (
-    AggregationMethod,
-    HistoricalPredictor,
     _OPERATOR_BASE_CONFIDENCE,
     _OPERATOR_MAX_CONFIDENCE,
+    AggregationMethod,
+    HistoricalPredictor,
     _aggregate,
     _compute_confidence,
     _filter_outliers,
@@ -45,7 +45,12 @@ TASK_ID = "test_task"
 CONTEXT = {"dag_id": DAG_ID}
 
 _PATCH_EXACT = "airflow.simulation.predictors.historical_predictor.get_historical_runtimes"
-_PATCH_OPERATOR = "airflow.simulation.predictors.historical_predictor.get_historical_runtimes_by_operator"
+_PATCH_OPERATOR = (
+    "airflow.simulation.predictors.historical_predictor.get_historical_runtimes_by_operator"
+)
+_PATCH_FINGERPRINT = (
+    "airflow.simulation.predictors.historical_predictor.get_historical_runtimes_by_fingerprint"
+)
 
 
 def _make_runtime(run_id: str, duration: float | None) -> HistoricalRuntime:
@@ -384,3 +389,130 @@ class TestHistoricalPredictorFullFallback:
 
         # Both have 5 runs < min_runs=10, falls to heuristic
         assert result.confidence == _DETERMINISTIC_CONFIDENCE
+
+
+# ---------------------------------------------------------------------------
+# Level 2: cross-DAG fingerprint match
+# ---------------------------------------------------------------------------
+
+
+_FINGERPRINT_CONTEXT = {"dag_id": DAG_ID, "task_fingerprint": "abc123"}
+
+
+class TestHistoricalPredictorFingerprintFallback:
+    """Pin the fingerprint fallback's position between exact match and operator-only."""
+
+    def test_fingerprint_used_when_exact_insufficient(self):
+        # Exact match has only 1 run (below min_runs); fingerprint has plenty.
+        exact_runtimes = [_make_runtime("r1", 10.0)]
+        fp_runtimes = [_make_runtime(f"r{i}", 100.0) for i in range(5)]
+
+        predictor = HistoricalPredictor(filter_outliers=False)
+
+        with (
+            patch(_PATCH_EXACT, return_value=exact_runtimes),
+            patch(_PATCH_FINGERPRINT, return_value=fp_runtimes) as fp_mock,
+            patch(_PATCH_OPERATOR, return_value=[]) as op_mock,
+        ):
+            result = predictor.estimate_task(
+                TASK_ID, OperatorType.PYTHON, _FINGERPRINT_CONTEXT
+            )
+
+        # Result reflects fingerprint data (median=100), not exact (10).
+        assert result.estimated_seconds == 100
+        # Operator query should not even be reached.
+        op_mock.assert_not_called()
+        # Fingerprint query was called with the fingerprint from context.
+        fp_mock.assert_called_once()
+        assert fp_mock.call_args.args[0] == "abc123"
+
+    def test_fingerprint_skipped_when_context_lacks_fingerprint(self):
+        # Context has no "task_fingerprint" key — predictor must skip Level 2
+        # and fall through to operator-type without ever calling the
+        # fingerprint extractor.
+        exact_runtimes = [_make_runtime("r1", 10.0)]
+        operator_runtimes = [_make_runtime(f"r{i}", 50.0) for i in range(5)]
+
+        predictor = HistoricalPredictor(filter_outliers=False)
+
+        with (
+            patch(_PATCH_EXACT, return_value=exact_runtimes),
+            patch(_PATCH_FINGERPRINT, return_value=[]) as fp_mock,
+            patch(_PATCH_OPERATOR, return_value=operator_runtimes),
+        ):
+            predictor.estimate_task(TASK_ID, OperatorType.PYTHON, CONTEXT)
+
+        fp_mock.assert_not_called()
+
+    def test_fingerprint_skipped_when_fingerprint_is_none(self):
+        # An explicit None fingerprint (the helper's "no signal" return) should
+        # also skip Level 2.
+        predictor = HistoricalPredictor(filter_outliers=False)
+
+        with (
+            patch(_PATCH_EXACT, return_value=[]),
+            patch(_PATCH_FINGERPRINT, return_value=[]) as fp_mock,
+            patch(_PATCH_OPERATOR, return_value=[]),
+        ):
+            predictor.estimate_task(
+                TASK_ID,
+                OperatorType.PYTHON,
+                {"dag_id": DAG_ID, "task_fingerprint": None},
+            )
+
+        fp_mock.assert_not_called()
+
+    def test_fingerprint_falls_through_when_below_min_runs(self):
+        # Fingerprint level returns 1 run (below min_runs); predictor should
+        # fall through to operator-type instead of using bad data.
+        operator_runtimes = [_make_runtime(f"r{i}", 50.0) for i in range(5)]
+
+        predictor = HistoricalPredictor(filter_outliers=False)
+
+        with (
+            patch(_PATCH_EXACT, return_value=[]),
+            patch(_PATCH_FINGERPRINT, return_value=[_make_runtime("only", 100.0)]),
+            patch(_PATCH_OPERATOR, return_value=operator_runtimes),
+        ):
+            result = predictor.estimate_task(
+                TASK_ID, OperatorType.PYTHON, _FINGERPRINT_CONTEXT
+            )
+
+        # Result should reflect the operator-level estimate (50), not the
+        # singleton fingerprint match (100).
+        assert result.estimated_seconds == 50
+
+    def test_fingerprint_confidence_is_between_exact_and_operator(self):
+        # Same number of samples at fingerprint and operator levels — verify
+        # the confidence ordering: exact > fingerprint > operator > heuristic.
+        runtimes = [_make_runtime(f"r{i}", 50.0) for i in range(5)]
+
+        predictor = HistoricalPredictor(filter_outliers=False)
+
+        with (
+            patch(_PATCH_EXACT, return_value=runtimes),
+            patch(_PATCH_FINGERPRINT, return_value=[]),
+            patch(_PATCH_OPERATOR, return_value=[]),
+        ):
+            exact_result = predictor.estimate_task(
+                TASK_ID, OperatorType.PYTHON, _FINGERPRINT_CONTEXT
+            )
+        with (
+            patch(_PATCH_EXACT, return_value=[]),
+            patch(_PATCH_FINGERPRINT, return_value=runtimes),
+            patch(_PATCH_OPERATOR, return_value=[]),
+        ):
+            fp_result = predictor.estimate_task(
+                TASK_ID, OperatorType.PYTHON, _FINGERPRINT_CONTEXT
+            )
+        with (
+            patch(_PATCH_EXACT, return_value=[]),
+            patch(_PATCH_FINGERPRINT, return_value=[]),
+            patch(_PATCH_OPERATOR, return_value=runtimes),
+        ):
+            op_result = predictor.estimate_task(
+                TASK_ID, OperatorType.PYTHON, _FINGERPRINT_CONTEXT
+            )
+
+        assert exact_result.confidence > fp_result.confidence > op_result.confidence
+        assert op_result.confidence > _DETERMINISTIC_CONFIDENCE

--- a/airflow-core/tests/unit/simulation/predictors/test_success_predictor.py
+++ b/airflow-core/tests/unit/simulation/predictors/test_success_predictor.py
@@ -29,6 +29,8 @@ from unittest.mock import patch
 import pytest
 
 from airflow.simulation.predictors.success_predictor import (
+    _DAG_SUCCESS_STATES,
+    _TASK_SUCCESS_STATES,
     SuccessPredictor,
     WeightingMethod,
     _compute_weights,
@@ -38,7 +40,14 @@ from airflow.simulation.predictors.success_predictor import (
 DAG_ID = "test_dag"
 TASK_ID = "test_task"
 
-_PATCH_HISTORY = "airflow.simulation.predictors.success_predictor.get_task_state_history"
+_PATCH_TASK_HISTORY = (
+    "airflow.simulation.predictors.success_predictor.get_task_state_history"
+)
+_PATCH_DAG_HISTORY = (
+    "airflow.simulation.predictors.success_predictor.get_dag_run_state_history"
+)
+# Backwards-compat alias for tests that only exercise the per-task path.
+_PATCH_HISTORY = _PATCH_TASK_HISTORY
 
 
 # ---------------------------------------------------------------------------
@@ -87,38 +96,57 @@ class TestComputeWeights:
 
 class TestWeightedSuccessRate:
     def test_all_success_returns_one(self):
-        rate = _weighted_success_rate(["success"] * 4, [1.0] * 4)
+        rate = _weighted_success_rate(["success"] * 4, [1.0] * 4, _TASK_SUCCESS_STATES)
 
         assert rate == 1.0
 
     def test_all_failed_returns_zero(self):
-        rate = _weighted_success_rate(["failed"] * 4, [1.0] * 4)
+        rate = _weighted_success_rate(["failed"] * 4, [1.0] * 4, _TASK_SUCCESS_STATES)
 
         assert rate == 0.0
 
     def test_mixed_with_uniform_weights(self):
         rate = _weighted_success_rate(
-            ["success", "success", "success", "failed"], [1.0, 1.0, 1.0, 1.0]
+            ["success", "success", "success", "failed"],
+            [1.0, 1.0, 1.0, 1.0],
+            _TASK_SUCCESS_STATES,
         )
 
         assert rate == pytest.approx(0.75)
 
-    def test_non_success_states_count_as_failure(self):
-        # Per the predictor's contract, anything not "success" is a failure.
+    def test_task_success_set_includes_skipped_and_removed(self):
+        # Per-task semantics: ``skipped`` and ``removed`` count as success.
+        # Only ``failed`` and ``upstream_failed`` are real failures.
         rate = _weighted_success_rate(
-            ["success", "failed", "skipped", "upstream_failed"],
-            [1.0, 1.0, 1.0, 1.0],
+            ["success", "skipped", "removed", "failed", "upstream_failed"],
+            [1.0] * 5,
+            _TASK_SUCCESS_STATES,
         )
 
-        assert rate == pytest.approx(0.25)
+        # 3 of 5 (success + skipped + removed) counted as success.
+        assert rate == pytest.approx(0.6)
+
+    def test_dag_success_set_excludes_skipped(self):
+        # DAG-level semantics: only ``success`` counts. There is no DAG-level
+        # ``skipped`` state — but feeding one in would correctly count as
+        # not-success under the strict DAG set.
+        rate = _weighted_success_rate(
+            ["success", "success", "failed"],
+            [1.0, 1.0, 1.0],
+            _DAG_SUCCESS_STATES,
+        )
+
+        assert rate == pytest.approx(2 / 3)
 
     def test_recent_failure_weighs_more_with_linear_weighting(self):
         # Newest run failed, older 3 succeeded — linear weighting should pull
         # the rate below the uniform 0.75.
         states = ["failed", "success", "success", "success"]
-        uniform = _weighted_success_rate(states, [1.0, 1.0, 1.0, 1.0])
+        uniform = _weighted_success_rate(states, [1.0, 1.0, 1.0, 1.0], _TASK_SUCCESS_STATES)
         weighted = _weighted_success_rate(
-            states, _compute_weights(4, WeightingMethod.LINEAR, decay_lambda=0.1)
+            states,
+            _compute_weights(4, WeightingMethod.LINEAR, decay_lambda=0.1),
+            _TASK_SUCCESS_STATES,
         )
 
         assert weighted < uniform
@@ -126,7 +154,7 @@ class TestWeightedSuccessRate:
     def test_zero_total_weight_returns_zero(self):
         # Defensive: shouldn't happen in practice (weights are positive), but
         # the function must not divide by zero.
-        rate = _weighted_success_rate(["success"], [0.0])
+        rate = _weighted_success_rate(["success"], [0.0], _TASK_SUCCESS_STATES)
 
         assert rate == 0.0
 
@@ -154,6 +182,33 @@ class TestPredictTaskSuccess:
 
         with patch(_PATCH_HISTORY, return_value=["failed"] * 5):
             assert predictor.predict_task_success(DAG_ID, TASK_ID) == 0.0
+
+    def test_skipped_runs_count_as_success(self):
+        # Branching DAGs steer around tasks; ``skipped`` is normal operation,
+        # not a failure mode. Pinning this explicitly because the original
+        # implementation treated everything-but-success as failure and made
+        # branched-around tasks score very low.
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["skipped"] * 5):
+            assert predictor.predict_task_success(DAG_ID, TASK_ID) == 1.0
+
+    def test_mixed_success_and_skipped_returns_one(self):
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["success", "skipped", "skipped", "success"]):
+            assert predictor.predict_task_success(DAG_ID, TASK_ID) == 1.0
+
+    def test_failed_states_still_lower_score(self):
+        # ``failed`` and ``upstream_failed`` are the only states that should
+        # bring per-task probability below 1.0.
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(
+            _PATCH_HISTORY, return_value=["success", "skipped", "failed", "upstream_failed"]
+        ):
+            # 2 of 4 (success + skipped) count; failed + upstream_failed do not.
+            assert predictor.predict_task_success(DAG_ID, TASK_ID) == pytest.approx(0.5)
 
     def test_uniform_weighting_returns_simple_ratio(self):
         # 3 of 4 = 0.75
@@ -225,62 +280,111 @@ class TestPredictTaskSuccess:
 # ---------------------------------------------------------------------------
 
 
+class TestPredictDagSuccessRate:
+    """``predict_dag_success_rate`` reads DagRun.state history directly."""
+
+    def test_returns_default_when_below_min_runs(self):
+        predictor = SuccessPredictor(min_runs=3, default_probability=0.42)
+
+        with patch(_PATCH_DAG_HISTORY, return_value=["success", "success"]):
+            assert predictor.predict_dag_success_rate(DAG_ID) == 0.42
+
+    def test_all_success_returns_one(self):
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_DAG_HISTORY, return_value=["success"] * 5):
+            assert predictor.predict_dag_success_rate(DAG_ID) == 1.0
+
+    def test_all_failed_returns_zero(self):
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_DAG_HISTORY, return_value=["failed"] * 5):
+            assert predictor.predict_dag_success_rate(DAG_ID) == 0.0
+
+    def test_mixed_returns_simple_ratio(self):
+        # 3 of 4 = 0.75
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(
+            _PATCH_DAG_HISTORY,
+            return_value=["success", "success", "success", "failed"],
+        ):
+            assert predictor.predict_dag_success_rate(DAG_ID) == pytest.approx(0.75)
+
+    def test_uses_max_runs_as_limit_for_dag_query(self):
+        predictor = SuccessPredictor(max_runs=42, min_runs=3)
+
+        with patch(_PATCH_DAG_HISTORY, return_value=["success"] * 3) as mock_history:
+            predictor.predict_dag_success_rate(DAG_ID)
+
+            assert mock_history.call_args.kwargs["limit"] == 42
+
+
 class TestPredictDagSuccess:
-    def test_empty_task_list_returns_default(self):
-        predictor = SuccessPredictor(default_probability=0.42)
+    """``predict_dag_success`` returns (dag_prob, per_task_probs).
 
-        dag_prob, per_task = predictor.predict_dag_success(DAG_ID, [])
+    DAG probability comes from DagRun history, NOT from multiplying per-task
+    probabilities — this prevents geometric decay across many tasks and lets
+    branching DAGs (where many tasks are routinely skipped) score correctly.
+    """
 
-        assert dag_prob == 0.42
+    def test_empty_task_list_still_returns_dag_probability(self):
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_DAG_HISTORY, return_value=["success"] * 3):
+            dag_prob, per_task = predictor.predict_dag_success(DAG_ID, [])
+
+        assert dag_prob == 1.0
         assert per_task == {}
 
-    def test_single_task_dag_probability_equals_task_probability(self):
+    def test_dag_probability_independent_of_per_task_probabilities(self):
+        # Per-task data says everything fails; DagRun data says everything
+        # succeeded. The DAG-level number must reflect the DagRun history.
+        # This is the bug fix for branching DAGs scoring as failure.
         predictor = SuccessPredictor(min_runs=3)
 
-        with patch(_PATCH_HISTORY, return_value=["success", "success", "success", "failed"]):
-            dag_prob, per_task = predictor.predict_dag_success(DAG_ID, ["t1"])
+        with patch(_PATCH_TASK_HISTORY, return_value=["failed"] * 3):
+            with patch(_PATCH_DAG_HISTORY, return_value=["success"] * 5):
+                dag_prob, per_task = predictor.predict_dag_success(DAG_ID, ["a", "b", "c"])
 
-        assert per_task == {"t1": pytest.approx(0.75)}
-        assert dag_prob == pytest.approx(0.75)
+        assert dag_prob == 1.0
+        # Per-task probabilities are still surfaced for the UI, just not
+        # multiplied into the DAG number.
+        assert per_task == {"a": 0.0, "b": 0.0, "c": 0.0}
 
-    def test_independent_tasks_multiply(self):
-        # t1 → 1.0, t2 → 0.5; expected DAG prob = 0.5
+    def test_branching_dag_scenario_scores_high(self):
+        # Regression test for the example_branch_operator_decorator bug:
+        # tasks routinely skipped should not pull DAG probability to zero,
+        # because (a) skipped now counts as task-level success and (b) the
+        # DAG number is computed from DagRun history.
         predictor = SuccessPredictor(min_runs=3)
 
-        def fake_history(dag_id, task_id, **_kwargs):
+        def fake_task_history(dag_id, task_id, **_kwargs):
             del dag_id
-            if task_id == "t1":
-                return ["success"] * 3
-            return ["success", "success", "failed", "failed"]
+            # ``branch_b`` is routinely skipped because branching steers
+            # around it; older skipped runs + 1 success on a recent pick.
+            if task_id == "branch_b":
+                return ["skipped", "skipped", "skipped", "success", "skipped"]
+            return ["success"] * 5
 
-        with patch(_PATCH_HISTORY, side_effect=fake_history):
-            dag_prob, per_task = predictor.predict_dag_success(DAG_ID, ["t1", "t2"])
+        with patch(_PATCH_TASK_HISTORY, side_effect=fake_task_history):
+            with patch(_PATCH_DAG_HISTORY, return_value=["success"] * 10):
+                dag_prob, per_task = predictor.predict_dag_success(
+                    DAG_ID, ["branch_a", "branch_b", "branch_c"]
+                )
 
-        assert per_task["t1"] == pytest.approx(1.0)
-        assert per_task["t2"] == pytest.approx(0.5)
-        assert dag_prob == pytest.approx(0.5)
-
-    def test_any_zero_probability_zeros_dag_probability(self):
-        # Independence assumption: if one task has 0% success, the DAG must too.
-        predictor = SuccessPredictor(min_runs=3)
-
-        def fake_history(dag_id, task_id, **_kwargs):
-            del dag_id
-            if task_id == "broken":
-                return ["failed"] * 3
-            return ["success"] * 3
-
-        with patch(_PATCH_HISTORY, side_effect=fake_history):
-            dag_prob, per_task = predictor.predict_dag_success(DAG_ID, ["ok", "broken"])
-
-        assert per_task["broken"] == 0.0
-        assert dag_prob == 0.0
+        assert dag_prob == 1.0
+        # branch_b: 5/5 (skipped + success both count) → 1.0
+        assert per_task["branch_b"] == pytest.approx(1.0)
+        assert per_task["branch_a"] == pytest.approx(1.0)
+        assert per_task["branch_c"] == pytest.approx(1.0)
 
     def test_per_task_dict_includes_every_requested_task_id(self):
         predictor = SuccessPredictor(min_runs=3)
 
-        with patch(_PATCH_HISTORY, return_value=["success"] * 3):
-            _, per_task = predictor.predict_dag_success(DAG_ID, ["a", "b", "c"])
+        with patch(_PATCH_TASK_HISTORY, return_value=["success"] * 3):
+            with patch(_PATCH_DAG_HISTORY, return_value=["success"] * 3):
+                _, per_task = predictor.predict_dag_success(DAG_ID, ["a", "b", "c"])
 
         assert set(per_task) == {"a", "b", "c"}
 

--- a/airflow-core/tests/unit/simulation/predictors/test_success_predictor.py
+++ b/airflow-core/tests/unit/simulation/predictors/test_success_predictor.py
@@ -1,0 +1,299 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for :class:`SuccessPredictor`.
+
+DB calls are mocked via ``unittest.mock.patch`` so these tests run without
+infrastructure. Integration coverage with seeded DAG-runs lives in the
+api_fastapi simulation endpoint tests.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import patch
+
+import pytest
+
+from airflow.simulation.predictors.success_predictor import (
+    SuccessPredictor,
+    WeightingMethod,
+    _compute_weights,
+    _weighted_success_rate,
+)
+
+DAG_ID = "test_dag"
+TASK_ID = "test_task"
+
+_PATCH_HISTORY = "airflow.simulation.predictors.success_predictor.get_task_state_history"
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWeights:
+    def test_none_weighting_uniform(self):
+        weights = _compute_weights(4, WeightingMethod.NONE, decay_lambda=0.1)
+
+        assert weights == [1.0, 1.0, 1.0, 1.0]
+
+    def test_linear_weighting_decreases_with_age(self):
+        weights = _compute_weights(4, WeightingMethod.LINEAR, decay_lambda=0.1)
+
+        # Newest first: highest weight at index 0, lowest at the end.
+        assert weights == [4.0, 3.0, 2.0, 1.0]
+        # Strictly decreasing.
+        assert all(weights[i] > weights[i + 1] for i in range(len(weights) - 1))
+
+    def test_exponential_weighting_decays(self):
+        weights = _compute_weights(3, WeightingMethod.EXPONENTIAL, decay_lambda=1.0)
+
+        # weights[i] = exp(-1.0 * i)
+        assert weights[0] == pytest.approx(1.0)
+        assert weights[1] == pytest.approx(math.exp(-1.0))
+        assert weights[2] == pytest.approx(math.exp(-2.0))
+        # Decay rate is steeper than linear for the same length.
+        linear = _compute_weights(3, WeightingMethod.LINEAR, decay_lambda=1.0)
+        ratio_exp = weights[2] / weights[0]
+        ratio_linear = linear[2] / linear[0]
+        assert ratio_exp < ratio_linear
+
+    def test_zero_runs_returns_empty(self):
+        assert _compute_weights(0, WeightingMethod.NONE, decay_lambda=0.1) == []
+
+    @pytest.mark.parametrize(
+        "method", [WeightingMethod.NONE, WeightingMethod.LINEAR, WeightingMethod.EXPONENTIAL]
+    )
+    def test_all_methods_return_correct_length(self, method):
+        weights = _compute_weights(7, method, decay_lambda=0.1)
+
+        assert len(weights) == 7
+
+
+class TestWeightedSuccessRate:
+    def test_all_success_returns_one(self):
+        rate = _weighted_success_rate(["success"] * 4, [1.0] * 4)
+
+        assert rate == 1.0
+
+    def test_all_failed_returns_zero(self):
+        rate = _weighted_success_rate(["failed"] * 4, [1.0] * 4)
+
+        assert rate == 0.0
+
+    def test_mixed_with_uniform_weights(self):
+        rate = _weighted_success_rate(
+            ["success", "success", "success", "failed"], [1.0, 1.0, 1.0, 1.0]
+        )
+
+        assert rate == pytest.approx(0.75)
+
+    def test_non_success_states_count_as_failure(self):
+        # Per the predictor's contract, anything not "success" is a failure.
+        rate = _weighted_success_rate(
+            ["success", "failed", "skipped", "upstream_failed"],
+            [1.0, 1.0, 1.0, 1.0],
+        )
+
+        assert rate == pytest.approx(0.25)
+
+    def test_recent_failure_weighs_more_with_linear_weighting(self):
+        # Newest run failed, older 3 succeeded — linear weighting should pull
+        # the rate below the uniform 0.75.
+        states = ["failed", "success", "success", "success"]
+        uniform = _weighted_success_rate(states, [1.0, 1.0, 1.0, 1.0])
+        weighted = _weighted_success_rate(
+            states, _compute_weights(4, WeightingMethod.LINEAR, decay_lambda=0.1)
+        )
+
+        assert weighted < uniform
+
+    def test_zero_total_weight_returns_zero(self):
+        # Defensive: shouldn't happen in practice (weights are positive), but
+        # the function must not divide by zero.
+        rate = _weighted_success_rate(["success"], [0.0])
+
+        assert rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# SuccessPredictor.predict_task_success
+# ---------------------------------------------------------------------------
+
+
+class TestPredictTaskSuccess:
+    def test_returns_default_when_below_min_runs(self):
+        predictor = SuccessPredictor(min_runs=3, default_probability=0.42)
+
+        with patch(_PATCH_HISTORY, return_value=["success", "success"]):
+            assert predictor.predict_task_success(DAG_ID, TASK_ID) == 0.42
+
+    def test_returns_one_when_all_runs_succeeded(self):
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["success"] * 5):
+            assert predictor.predict_task_success(DAG_ID, TASK_ID) == 1.0
+
+    def test_returns_zero_when_all_runs_failed(self):
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["failed"] * 5):
+            assert predictor.predict_task_success(DAG_ID, TASK_ID) == 0.0
+
+    def test_uniform_weighting_returns_simple_ratio(self):
+        # 3 of 4 = 0.75
+        predictor = SuccessPredictor(min_runs=3, weighting=WeightingMethod.NONE)
+
+        with patch(_PATCH_HISTORY, return_value=["success", "success", "success", "failed"]):
+            assert predictor.predict_task_success(DAG_ID, TASK_ID) == pytest.approx(0.75)
+
+    def test_linear_weighting_biases_toward_recent(self):
+        predictor_linear = SuccessPredictor(
+            min_runs=3, weighting=WeightingMethod.LINEAR
+        )
+        predictor_uniform = SuccessPredictor(min_runs=3, weighting=WeightingMethod.NONE)
+        # Newest run failed; oldest 3 succeeded.
+        states = ["failed", "success", "success", "success"]
+
+        with patch(_PATCH_HISTORY, return_value=states):
+            linear_prob = predictor_linear.predict_task_success(DAG_ID, TASK_ID)
+        with patch(_PATCH_HISTORY, return_value=states):
+            uniform_prob = predictor_uniform.predict_task_success(DAG_ID, TASK_ID)
+
+        assert linear_prob < uniform_prob
+
+    def test_exponential_weighting_more_aggressive_than_linear(self):
+        states = ["failed", "success", "success", "success"]
+        linear = SuccessPredictor(min_runs=3, weighting=WeightingMethod.LINEAR)
+        exponential = SuccessPredictor(
+            min_runs=3, weighting=WeightingMethod.EXPONENTIAL, decay_lambda=1.0
+        )
+
+        with patch(_PATCH_HISTORY, return_value=states):
+            linear_prob = linear.predict_task_success(DAG_ID, TASK_ID)
+        with patch(_PATCH_HISTORY, return_value=states):
+            exp_prob = exponential.predict_task_success(DAG_ID, TASK_ID)
+
+        # Both penalize recent failure, but exponential weighs the recent run more.
+        assert exp_prob < linear_prob
+
+    def test_lookback_none_passes_no_start_date(self):
+        # When lookback_days is None, get_task_state_history should be called
+        # with start_date=None (i.e. no time-window restriction).
+        predictor = SuccessPredictor(lookback_days=None, min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["success"] * 3) as mock_history:
+            predictor.predict_task_success(DAG_ID, TASK_ID)
+
+            mock_history.assert_called_once()
+            assert mock_history.call_args.kwargs["start_date"] is None
+
+    def test_lookback_days_passes_start_date(self):
+        predictor = SuccessPredictor(lookback_days=14, min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["success"] * 3) as mock_history:
+            predictor.predict_task_success(DAG_ID, TASK_ID)
+
+            assert mock_history.call_args.kwargs["start_date"] is not None
+
+    def test_query_uses_max_runs_as_limit(self):
+        predictor = SuccessPredictor(max_runs=42, min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["success"] * 3) as mock_history:
+            predictor.predict_task_success(DAG_ID, TASK_ID)
+
+            assert mock_history.call_args.kwargs["limit"] == 42
+
+
+# ---------------------------------------------------------------------------
+# SuccessPredictor.predict_dag_success
+# ---------------------------------------------------------------------------
+
+
+class TestPredictDagSuccess:
+    def test_empty_task_list_returns_default(self):
+        predictor = SuccessPredictor(default_probability=0.42)
+
+        dag_prob, per_task = predictor.predict_dag_success(DAG_ID, [])
+
+        assert dag_prob == 0.42
+        assert per_task == {}
+
+    def test_single_task_dag_probability_equals_task_probability(self):
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["success", "success", "success", "failed"]):
+            dag_prob, per_task = predictor.predict_dag_success(DAG_ID, ["t1"])
+
+        assert per_task == {"t1": pytest.approx(0.75)}
+        assert dag_prob == pytest.approx(0.75)
+
+    def test_independent_tasks_multiply(self):
+        # t1 → 1.0, t2 → 0.5; expected DAG prob = 0.5
+        predictor = SuccessPredictor(min_runs=3)
+
+        def fake_history(dag_id, task_id, **_kwargs):
+            del dag_id
+            if task_id == "t1":
+                return ["success"] * 3
+            return ["success", "success", "failed", "failed"]
+
+        with patch(_PATCH_HISTORY, side_effect=fake_history):
+            dag_prob, per_task = predictor.predict_dag_success(DAG_ID, ["t1", "t2"])
+
+        assert per_task["t1"] == pytest.approx(1.0)
+        assert per_task["t2"] == pytest.approx(0.5)
+        assert dag_prob == pytest.approx(0.5)
+
+    def test_any_zero_probability_zeros_dag_probability(self):
+        # Independence assumption: if one task has 0% success, the DAG must too.
+        predictor = SuccessPredictor(min_runs=3)
+
+        def fake_history(dag_id, task_id, **_kwargs):
+            del dag_id
+            if task_id == "broken":
+                return ["failed"] * 3
+            return ["success"] * 3
+
+        with patch(_PATCH_HISTORY, side_effect=fake_history):
+            dag_prob, per_task = predictor.predict_dag_success(DAG_ID, ["ok", "broken"])
+
+        assert per_task["broken"] == 0.0
+        assert dag_prob == 0.0
+
+    def test_per_task_dict_includes_every_requested_task_id(self):
+        predictor = SuccessPredictor(min_runs=3)
+
+        with patch(_PATCH_HISTORY, return_value=["success"] * 3):
+            _, per_task = predictor.predict_dag_success(DAG_ID, ["a", "b", "c"])
+
+        assert set(per_task) == {"a", "b", "c"}
+
+
+class TestConstructorValidation:
+    @pytest.mark.parametrize("invalid", [-0.1, 1.1, 2.0, -1.0])
+    def test_default_probability_must_be_in_unit_interval(self, invalid):
+        with pytest.raises(ValueError, match=r"\[0\.0, 1\.0\]"):
+            SuccessPredictor(default_probability=invalid)
+
+    def test_min_runs_clamped_to_at_least_one(self):
+        # Defensive: a 0 or negative min_runs would let a zero-history task
+        # produce a divide-by-zero or a 0-of-0 reading.
+        predictor = SuccessPredictor(min_runs=0)
+
+        assert predictor.min_runs == 1

--- a/airflow-core/tests/unit/simulation/predictors/test_success_predictor.py
+++ b/airflow-core/tests/unit/simulation/predictors/test_success_predictor.py
@@ -276,6 +276,72 @@ class TestPredictTaskSuccess:
 
 
 # ---------------------------------------------------------------------------
+# SuccessPredictor.count_task_outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestCountTaskOutcomes:
+    def test_returns_zero_counts_when_no_history(self):
+        predictor = SuccessPredictor()
+
+        with patch(_PATCH_HISTORY, return_value=[]):
+            assert predictor.count_task_outcomes(DAG_ID, TASK_ID) == (0, 0, 0)
+
+    def test_counts_pure_success_history(self):
+        predictor = SuccessPredictor()
+
+        with patch(_PATCH_HISTORY, return_value=["success"] * 5):
+            total, success, failed = predictor.count_task_outcomes(DAG_ID, TASK_ID)
+
+        assert (total, success, failed) == (5, 5, 0)
+
+    def test_counts_pure_failed_history(self):
+        predictor = SuccessPredictor()
+
+        with patch(_PATCH_HISTORY, return_value=["failed"] * 4):
+            assert predictor.count_task_outcomes(DAG_ID, TASK_ID) == (4, 0, 4)
+
+    def test_failed_count_includes_upstream_failed(self):
+        # ``upstream_failed`` is a real failure mode (a parent task failed),
+        # so it counts toward the ``failed`` column even though the task
+        # itself never ran.
+        predictor = SuccessPredictor()
+
+        with patch(_PATCH_HISTORY, return_value=["failed", "upstream_failed", "success"]):
+            total, success, failed = predictor.count_task_outcomes(DAG_ID, TASK_ID)
+
+        assert (total, success, failed) == (3, 1, 2)
+
+    def test_skipped_and_removed_count_in_total_only(self):
+        # Skipped/removed are part of normal operation — they appear in the
+        # total but not in either success or failed.
+        predictor = SuccessPredictor()
+
+        with patch(
+            _PATCH_HISTORY,
+            return_value=["success", "skipped", "removed", "failed"],
+        ):
+            total, success, failed = predictor.count_task_outcomes(DAG_ID, TASK_ID)
+
+        assert (total, success, failed) == (4, 1, 1)
+        # Sanity: the gap between total and (success + failed) is the count
+        # of "neither" states (here: skipped + removed = 2).
+        assert total - (success + failed) == 2
+
+    def test_uses_same_lookback_and_limit_as_predict_task_success(self):
+        # The counts must reflect what the predictor sees, not a different
+        # subset of history — same start_date and limit kwargs.
+        predictor = SuccessPredictor(lookback_days=14, max_runs=42)
+
+        with patch(_PATCH_HISTORY, return_value=["success"] * 3) as mock_history:
+            predictor.count_task_outcomes(DAG_ID, TASK_ID)
+
+            kwargs = mock_history.call_args.kwargs
+            assert kwargs["start_date"] is not None
+            assert kwargs["limit"] == 42
+
+
+# ---------------------------------------------------------------------------
 # SuccessPredictor.predict_dag_success
 # ---------------------------------------------------------------------------
 

--- a/airflow-core/tests/unit/simulation/test_fingerprint.py
+++ b/airflow-core/tests/unit/simulation/test_fingerprint.py
@@ -1,0 +1,158 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for ``compute_task_fingerprint``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from airflow.simulation.fingerprint import compute_task_fingerprint
+
+# Stand-in operator types: SimpleNamespace mimics duck-typed access to
+# attributes the fingerprint helper inspects, while ``type().__name__`` is the
+# operator class name used as the first signal.
+
+
+class FakePythonOperator(SimpleNamespace):
+    pass
+
+
+class FakeBashOperator(SimpleNamespace):
+    pass
+
+
+class FakeSqlOperator(SimpleNamespace):
+    pass
+
+
+class FakeKubernetesPodOperator(SimpleNamespace):
+    pass
+
+
+class FakeBareOperator(SimpleNamespace):
+    """Operator with no work-signal attributes — matches the 'no signal' case."""
+
+
+def _func_a():
+    return 1
+
+
+def _func_b():
+    return 2
+
+
+class TestNoSignalReturnsNone:
+    def test_operator_with_no_attributes_returns_none(self):
+        # No callable, no bash_command, no sql, no image — fingerprint adds
+        # no information beyond the operator class.
+        task = FakeBareOperator()
+
+        assert compute_task_fingerprint(task) is None
+
+    def test_python_operator_with_none_callable_returns_none(self):
+        task = FakePythonOperator(python_callable=None)
+
+        assert compute_task_fingerprint(task) is None
+
+    def test_bash_operator_with_empty_command_returns_none(self):
+        task = FakeBashOperator(bash_command="")
+
+        assert compute_task_fingerprint(task) is None
+
+
+class TestStability:
+    def test_same_callable_yields_same_fingerprint(self):
+        a = FakePythonOperator(python_callable=_func_a)
+        b = FakePythonOperator(python_callable=_func_a)
+
+        assert compute_task_fingerprint(a) == compute_task_fingerprint(b)
+
+    def test_different_callables_yield_different_fingerprints(self):
+        a = FakePythonOperator(python_callable=_func_a)
+        b = FakePythonOperator(python_callable=_func_b)
+
+        assert compute_task_fingerprint(a) != compute_task_fingerprint(b)
+
+    def test_same_bash_command_yields_same_fingerprint(self):
+        a = FakeBashOperator(bash_command="echo hello")
+        b = FakeBashOperator(bash_command="echo hello")
+
+        assert compute_task_fingerprint(a) == compute_task_fingerprint(b)
+
+    def test_different_bash_commands_yield_different_fingerprints(self):
+        a = FakeBashOperator(bash_command="echo hello")
+        b = FakeBashOperator(bash_command="echo goodbye")
+
+        assert compute_task_fingerprint(a) != compute_task_fingerprint(b)
+
+    def test_same_sql_yields_same_fingerprint(self):
+        a = FakeSqlOperator(sql="SELECT 1")
+        b = FakeSqlOperator(sql="SELECT 1")
+
+        assert compute_task_fingerprint(a) == compute_task_fingerprint(b)
+
+
+class TestOperatorClassNameMatters:
+    def test_same_attributes_different_class_yield_different_fingerprints(self):
+        # Two operator classes that happen to expose the same attribute name
+        # ("script") with the same value should not collide if their class
+        # names differ — the operator class is part of the fingerprint.
+        bash = FakeBashOperator(bash_command="echo hi")
+        sql = FakeSqlOperator(sql="echo hi")
+
+        assert compute_task_fingerprint(bash) != compute_task_fingerprint(sql)
+
+    def test_python_qualname_differentiates_methods(self):
+        class HelperA:
+            @staticmethod
+            def run():
+                return None
+
+        class HelperB:
+            @staticmethod
+            def run():
+                return None
+
+        a = FakePythonOperator(python_callable=HelperA.run)
+        b = FakePythonOperator(python_callable=HelperB.run)
+
+        assert compute_task_fingerprint(a) != compute_task_fingerprint(b)
+
+
+class TestImageSignal:
+    def test_same_image_yields_same_fingerprint(self):
+        a = FakeKubernetesPodOperator(image="ghcr.io/team/app:1.0")
+        b = FakeKubernetesPodOperator(image="ghcr.io/team/app:1.0")
+
+        assert compute_task_fingerprint(a) == compute_task_fingerprint(b)
+
+    def test_different_image_tags_yield_different_fingerprints(self):
+        a = FakeKubernetesPodOperator(image="ghcr.io/team/app:1.0")
+        b = FakeKubernetesPodOperator(image="ghcr.io/team/app:2.0")
+
+        assert compute_task_fingerprint(a) != compute_task_fingerprint(b)
+
+
+class TestFingerprintShape:
+    def test_fingerprint_is_a_short_hex_string(self):
+        task = FakeBashOperator(bash_command="echo hi")
+        fingerprint = compute_task_fingerprint(task)
+
+        assert fingerprint is not None
+        assert isinstance(fingerprint, str)
+        assert len(fingerprint) == 16
+        assert all(char in "0123456789abcdef" for char in fingerprint)


### PR DESCRIPTION
  Implements [#32 (SuccessPredictor)](https://github.com/cs5150-team19/airflow/issues/32) and lands four follow-on     
  improvements that surfaced during review and user testing.                                                           
                                                                                                                       
  **Backend**                                                                                                          
                                                                                                                     
  - New `SuccessPredictor` (`airflow-core/src/airflow/simulation/predictors/success_predictor.py`)                     
    predicting task and DAG success probability from historical state data, with three                               
    weighting modes (none / linear / exponential) and a configurable lookback window.                                  
  - New cross-DAG fingerprint matching (`airflow-core/src/airflow/simulation/fingerprint.py`)                          
    inserted as a new fallback level in `HistoricalPredictor` between exact-match and                                  
    operator-only:                                                                                                     
    Level 1: exact (dag_id, task_id)         confidence 0.7–0.95                                                       
    Level 2: cross-DAG fingerprint           confidence 0.6–0.85   ← NEW                                               
    Level 3: same operator (cross-DAG)       confidence 0.55–0.75                                                    
    Level 4: deterministic constant          confidence 0.5                                                            
                                                                                                                       
  - Three new extractor functions: `get_task_state_history`,                                                           
  `get_dag_run_state_history`, `get_historical_runtimes_by_fingerprint`.                                               
  - Five new fields on `TaskSimulationResponse` / `SimulationResponse`:                                                
  `success_probability`, `task_success_probabilities`, `historical_total`,                                             
  `historical_success`, `historical_failed`.                                                                           
                                                                                                                       
  **UI**                                                                                                               
                                                                                                                     
  - New "Success Probability" overlay toggle (`?sim_success=1`) in the Simulation                                      
  - DAG-level probability tile and per-task probability column on the Simulation page.
  - Three new history columns (Total / Succeeded / Failed) showing the                                                 
  same-`(dag_id, task_id)` data the predictors saw.                                                                    
  - Per-task probability tile in Task Overview's Simulation View.                                                      
                                                                                                                       
  **Behavior changes worth flagging**                                                                                  
                                                                                                                       
  1. `total_estimated_seconds` now reports the **critical-path runtime** (true lower                                   
   bound under parallelism), not the serial sum. Field name unchanged; consumers                                       
   expecting "sum of every task's estimate" will see smaller numbers for any                                         
   wide DAG.                                                                                                           
  2. DAG-level `success_probability` is computed from `DagRun.state` history, not by                                   
   multiplying per-task probabilities. Per-task probabilities remain in the                                            
   response for the UI table but no longer feed the DAG number — fixes the                                             
   geometric-decay bug where any DAG with ~10 tasks and no history predicted                                         
   failure.                                                                                                            
  3. `skipped` and `removed` task states now count as task-level success                                               
   (`_TASK_SUCCESS_STATES`). Branching DAGs (`example_branch_operator_decorator`)                                      
   were previously mispredicted as failure because branched-around tasks scored                                        
   0% success.                                                                                                         
                                                                                                                       
  **Tests**                                                                                                            
                                                                                                                       
  ~110 new tests across:                                                                                             
                                                                                                                       
  - `tests/unit/simulation/test_fingerprint.py` (new) — 14 tests
  - `tests/unit/simulation/predictors/test_success_predictor.py` (new) — ~50 tests                                     
  - `tests/unit/simulation/predictors/test_historical_predictor.py` — 5 new tests                                    
  covering the fingerprint fallback level                                                                              
  - `tests/unit/api_fastapi/core_api/routes/public/test_simulation.py` — integration                                   
  tests with seeded DagRun + TaskInstance history, including a regression test                                         
  for the branching-DAG scenario                                                                                       
  - `airflow-core/src/airflow/ui/src/utils/simulationDisplay.test.ts` — Vitest                                         
  coverage for `sim_success`, `formatProbabilityPercent`, and the new label paths                                      
                                                                                                                       
  closes: #32                                                                                                          
                                                                                                                       
  ---                                                                                                                  
                                                                                                                     
  ##### Was generative AI tooling used to co-author this PR?                                                         
                                                                                                                       
  - [X] Yes — Claude Code (claude-opus-4-7)
                                                                                                                       
  Generated-by: Claude Code (claude-opus-4-7) following [the guidelines](https://github.com/apache/airflow/blob/main/co
  ntributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)                                                  
                                                                                                                     
  ---                                                                                                                  
                                                                                                                     
  * Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests
  .rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become 
  permanently public when merged.                                                                                     
  * For fundamental code changes, an Airflow Improvement Proposal                                                      
  ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.              
  * When adding dependency, check compliance with the [ASF 3rd Party License                                           
  Policy](https://www.apache.org/legal/resolved.html#category-x).           
  * For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in                         
  [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add  
  this file in a follow-up commit after the PR is created so you know the PR number.                                   
                                                                                                                     
  To create the PR with this body filled in, copy the markdown above and use:                                          
  gh pr create --base feature --head success_predict --title "Implement SuccessPredictor and cross-DAG fingerprint     
  matching" --body-file -                                                                                            
  (then paste, then Ctrl+D)                                                                                            
                                                                                                                     
  Or via the web UI with the --web flag — but gh doesn't pre-fill body via --web, so paste it in manually after the    
  form opens.